### PR TITLE
Add catch all error handling

### DIFF
--- a/Assessments/assessments.json
+++ b/Assessments/assessments.json
@@ -12,10 +12,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "21513e76-197c-44bd-ae76-a8bdc7c9942c"
+      "uuid": "70b7ef96-c0a3-47f5-a484-97033504afb7"
     },
     {
       "values": [
@@ -26,10 +26,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "4ff25214-fccb-4161-b135-9580b142c215"
+      "uuid": "bf4f857d-33fd-4e64-817c-b23c4529abdd"
     },
     {
       "values": [
@@ -40,10 +40,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "47cb90b8-f97d-47ed-b1f6-8d582f9e5d4d"
+      "uuid": "93a8fe5c-b3a2-445f-a623-c1cd6b87b975"
     },
     {
       "values": [
@@ -54,10 +54,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "bab7e27e-bf0f-472b-ab9b-f51b8306b661"
+      "uuid": "f334b3a7-3e52-4e36-ae4c-e81efcb1b4c8"
     },
     {
       "values": [
@@ -68,10 +68,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "041bf2b3-f9e5-44d3-9eb0-a29ed6982385"
+      "uuid": "26394d94-90d4-4a6d-9250-025c686c1aa7"
     },
     {
       "values": [
@@ -82,10 +82,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "28ad428e-6dfd-4abf-b2bd-79e2634d57a3"
+      "uuid": "08ae260c-23d3-43b0-a600-59ed1c93ec57"
     },
     {
       "values": [
@@ -96,10 +96,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "28cd58d4-3c68-4a36-bbab-7ae65844e801"
+      "uuid": "e3b88db2-f9ef-4baf-966f-939406ccc8d1"
     },
     {
       "values": [
@@ -110,10 +110,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "58c52a5b-9ba4-4cd6-98f5-da5f56d64509"
+      "uuid": "94393505-0de7-4065-8ccf-495818280f82"
     },
     {
       "values": [
@@ -124,10 +124,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "a8d55d64-1d53-45bb-83a2-d87831a33da1"
+      "uuid": "249e2926-967b-41ac-9977-9f381dceb2f1"
     },
     {
       "values": [
@@ -138,10 +138,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "1f8eae2e-7658-4d14-a63f-0868a7a4c32b"
+      "uuid": "e717033c-9c9b-4e34-8b09-04b31a6d6a7c"
     },
     {
       "values": [
@@ -152,10 +152,24 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "99fb33ba-a2da-4416-8e55-e3c58851bd78"
+      "uuid": "3691f1f1-a350-43b5-8a22-ebf95462fbb0"
+    },
+    {
+      "values": [
+        {
+          "value": "Invalid input",
+          "modes": [
+            "RICH_MESSAGING"
+          ],
+          "content_type": "TEXT",
+          "mime_type": "text/plain",
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
+        }
+      ],
+      "uuid": "394d436d-253a-4b21-86e3-d8f76d9177a9"
     },
     {
       "values": [
@@ -166,10 +180,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "346dc839-aef7-42ed-a30d-f38e96532d22"
+      "uuid": "d485ca81-bd3f-42c1-9dc6-e1633ad4aac9"
     },
     {
       "values": [
@@ -180,10 +194,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "c69aba8d-439f-4576-ae7a-0fac4cec3b52"
+      "uuid": "507a4402-0633-4d9a-9156-00d8546560c1"
     },
     {
       "values": [
@@ -194,10 +208,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "024494ba-5049-4585-bb8b-bb923bec78e9"
+      "uuid": "b296083b-1595-44d2-8efa-997dfb42a4bd"
     },
     {
       "values": [
@@ -208,10 +222,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "65628f77-38d7-4152-9be3-4077ab299834"
+      "uuid": "7d3a7415-f4c8-4879-8914-c690a58bb51c"
     },
     {
       "values": [
@@ -222,10 +236,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "6df41d8a-1e2e-4300-925d-138bd39a6a0b"
+      "uuid": "0e508b36-f380-43ba-90ae-6ecea5246096"
     },
     {
       "values": [
@@ -236,10 +250,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "5698e24a-4b82-4f19-86a5-3e71935721a6"
+      "uuid": "ec00cbb6-8a9b-4b3f-bb31-9279372af647"
     },
     {
       "values": [
@@ -250,10 +264,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "0dcfa15b-fe6d-4a4d-8f48-9b5bce5b5ad1"
+      "uuid": "2cb93c4b-1ffd-476b-8826-f39001123109"
     },
     {
       "values": [
@@ -264,10 +278,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "0d8b4688-a3a8-41ce-b869-b07da0db04a1"
+      "uuid": "26ee15f9-cb25-474e-84cf-94747048e081"
     },
     {
       "values": [
@@ -278,10 +292,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "9f9e5d7f-cfcd-4f94-bc65-38251c99f1ad"
+      "uuid": "8e3570f5-3629-4362-b9c8-0dc34c31c620"
     },
     {
       "values": [
@@ -292,10 +306,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "9b643a11-a67d-4dcb-bb19-c3417c06f124"
+      "uuid": "17e1f784-af2c-4ce3-a872-e859545a0147"
     },
     {
       "values": [
@@ -306,10 +320,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "2cb075a4-9e6f-4b9c-a92a-46389735a807"
+      "uuid": "dae37736-b04f-4f1a-93ae-2054847f75a9"
     },
     {
       "values": [
@@ -320,10 +334,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "4005811b-54c4-4c91-a88d-2860d2d449d0"
+      "uuid": "ac160bef-0e8f-40ee-afdb-2c0e3ed33efc"
     },
     {
       "values": [
@@ -334,10 +348,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "4092f250-586d-484b-a76e-244cdb696513"
+      "uuid": "f56e0f5f-c0e3-4698-aa11-7dc7d23e2c53"
     },
     {
       "values": [
@@ -348,10 +362,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "df11f381-8706-4493-b54d-baea1f4c5a23"
+      "uuid": "1136a0ac-f2db-455c-8b97-a426c72be3c3"
     },
     {
       "values": [
@@ -362,10 +376,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "73e7ef0a-4e74-46da-9b18-6ca419c1dfe5"
+      "uuid": "d98ca178-a302-498d-b70c-9df8d33e83ba"
     },
     {
       "values": [
@@ -376,10 +390,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "0cfa26e3-dbc5-4249-833b-c6b75889bc8c"
+      "uuid": "f88f59fe-38c7-467a-a7f3-cea4235031e7"
     },
     {
       "values": [
@@ -390,10 +404,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "29c04201-8e62-444e-a081-ec356f61af2c"
+      "uuid": "7adac2e5-3a12-4d78-89b6-dc079e9d9158"
     },
     {
       "values": [
@@ -404,10 +418,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "c991582d-aeaa-47f8-aba1-5a89bb6e0fbb"
+      "uuid": "c7e32c67-f5de-4b30-ba72-1d2719b81f83"
     },
     {
       "values": [
@@ -418,10 +432,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "7661de26-31bc-49b5-8644-0a7799e60889"
+      "uuid": "6d38a2d0-5378-462c-8e13-a42963dd9b13"
     },
     {
       "values": [
@@ -432,10 +446,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "3e7b7e79-6ca1-4544-80ea-5bb6d94022f1"
+      "uuid": "f85b0cb7-f4f2-4771-9683-00ad826afe20"
     },
     {
       "values": [
@@ -446,10 +460,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "aead8a25-31de-4fd7-a431-4f1095abfad0"
+      "uuid": "bbf08dac-7735-4260-8b34-c1f01c56ca63"
     },
     {
       "values": [
@@ -460,10 +474,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "9b06e16c-13fd-4880-a9f0-8c2f73987fe6"
+      "uuid": "7ca8ede1-478d-4300-a4e3-b80a21af20c2"
     },
     {
       "values": [
@@ -474,10 +488,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "b92dd26b-b642-4999-8362-fc15caff8de1"
+      "uuid": "d214282a-66bc-4ad9-b7a2-9a3215626665"
     },
     {
       "values": [
@@ -488,10 +502,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "81b2add1-6e69-48d6-961f-1bef900b69c1"
+      "uuid": "930c61ec-860d-4e9d-9591-f6c9f663ab0d"
     },
     {
       "values": [
@@ -502,10 +516,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "a11de73b-3930-4931-b441-03e7aa42aa59"
+      "uuid": "80786f6e-35c4-49eb-9848-5a5c9e3a0cb8"
     },
     {
       "values": [
@@ -516,10 +530,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "5dace10e-ee8a-49b2-a149-83314ad40064"
+      "uuid": "90ac7e13-3177-465a-8882-3ab8bf02afd8"
     },
     {
       "values": [
@@ -530,10 +544,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "bf3b76d6-fe65-4fcf-a000-afd4eb779888"
+      "uuid": "864450d2-c91e-4187-a6d0-7d83b1f16ad4"
     },
     {
       "values": [
@@ -544,10 +558,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "ae69d167-2f72-4563-9292-bcc2f730a497"
+      "uuid": "8739b2fc-5a57-438a-85c3-5e454490d45f"
     },
     {
       "values": [
@@ -558,10 +572,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "ab120ec0-6946-43f4-8abc-c2f2f3601670"
+      "uuid": "a8220ecc-323d-4944-b64e-e6573f8d6297"
     },
     {
       "values": [
@@ -572,10 +586,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "b6a9aa32-f04c-4937-ab60-3961379e57e3"
+      "uuid": "20a07f23-ffd3-42c4-956f-40411771a9fc"
     },
     {
       "values": [
@@ -586,10 +600,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "76f51a4b-e7d7-4963-b1ee-95750f99e87e"
+      "uuid": "30a825ef-a5a7-41fc-9916-b10837333b46"
     },
     {
       "values": [
@@ -600,10 +614,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "2a906ef6-e587-49fc-b585-3a7a88cd5f88"
+      "uuid": "4d7ebb9e-379c-40c2-b2f8-a5d78fa6e83a"
     },
     {
       "values": [
@@ -614,10 +628,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "3636ee27-668e-4d9d-aaac-518bdc063cb9"
+      "uuid": "65c4f48f-dccf-4d29-aada-443e733b9ab5"
     },
     {
       "values": [
@@ -628,10 +642,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "e3fa56b3-9050-4819-aafd-88298df76420"
+      "uuid": "c9797882-020b-4f0e-b603-be06a1fbe3b3"
     },
     {
       "values": [
@@ -642,10 +656,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "91959c94-400c-4d6f-bffb-623dd3c94d0f"
+      "uuid": "4ac5d744-7e56-4b27-b518-e2a0cdde6e0c"
     },
     {
       "values": [
@@ -656,10 +670,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "ee008566-ae6a-421c-8874-2c579fe9d269"
+      "uuid": "4bfd8d2d-68fc-4975-9545-f523ade8e085"
     },
     {
       "values": [
@@ -670,7 +684,7 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         },
         {
           "value": "Select option",
@@ -679,10 +693,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "4deba3fb-b162-4ce0-b58f-18fd6ad01fb9"
+      "uuid": "0bbd4820-dd6e-4cb2-86dd-ca1ba018f9b2"
     },
     {
       "values": [
@@ -693,10 +707,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "bde5d46a-1fa4-4362-b0f8-c70c378ebd39"
+      "uuid": "71cf65a4-5840-487b-8d55-e2fb345db395"
     },
     {
       "values": [
@@ -707,10 +721,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "68f26ce1-7d2c-4113-ba3e-160b31fe8b59"
+      "uuid": "dfb51166-82f8-4e72-bea5-b6ddfeaef799"
     },
     {
       "values": [
@@ -721,10 +735,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "b8785e01-bdb5-436c-adfe-0a5e64bba080"
+      "uuid": "785be7e3-512b-43d6-99ba-915d6ca301d7"
     },
     {
       "values": [
@@ -735,10 +749,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "4c215ee5-0925-46c7-bbc9-78e30c74e75d"
+      "uuid": "ae05a509-2d92-4d7b-b67d-19667ab3f63a"
     },
     {
       "values": [
@@ -749,10 +763,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "c07f5a97-9564-4c3f-8266-1b27193438e2"
+      "uuid": "51811ee7-95db-41cf-ac13-9631b09217f4"
     },
     {
       "values": [
@@ -763,10 +777,10 @@
           ],
           "content_type": "TEXT",
           "mime_type": "text/plain",
-          "language_id": "09406b97-f5bb-458d-b787-5c67b8725848"
+          "language_id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639"
         }
       ],
-      "uuid": "8babea68-2f10-448d-99e8-dc06da303510"
+      "uuid": "a06dbf55-935f-4ff1-8a21-05e065bcb6d8"
     }
   ],
   "flows": [
@@ -780,7 +794,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "4a783711-66af-51b9-8123-fbb117fa66a4",
+          "uuid": "cc311bb4-1f77-5fbb-bb1b-2be1124b21c2",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -793,8 +807,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_score\")",
               "config": {},
               "test": "",
-              "uuid": "f2a59571-c6cd-431a-9804-1ed36670c112",
-              "destination_block": "48bcedb7-b36d-5df2-921b-2aa4ec9dc116",
+              "uuid": "e34fb559-4e58-4558-97ee-9173e7735559",
+              "destination_block": "583e34fa-fd5d-51f0-abcf-5670f3f495e3",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -809,7 +823,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -818,7 +832,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 521
+                        "line": 527
                       },
                       "type": "expression"
                     },
@@ -837,7 +851,7 @@
             "value": "score"
           },
           "tags": [],
-          "uuid": "48bcedb7-b36d-5df2-921b-2aa4ec9dc116",
+          "uuid": "583e34fa-fd5d-51f0-abcf-5670f3f495e3",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -850,8 +864,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "b99eb8ff-e869-469a-8f19-ef0b46c86e24",
-              "destination_block": "544797a3-5ac9-5e43-95eb-a7373d2679c2",
+              "uuid": "f762f920-aa23-4ad5-b35d-297508decc57",
+              "destination_block": "1ee8230f-d80f-58b2-92ea-dfb3d9163323",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -866,7 +880,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -874,7 +888,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 522
+                        "line": 528
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -892,7 +906,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "544797a3-5ac9-5e43-95eb-a7373d2679c2",
+          "uuid": "1ee8230f-d80f-58b2-92ea-dfb3d9163323",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -905,8 +919,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_max_score\")",
               "config": {},
               "test": "",
-              "uuid": "fc430a21-f746-4158-b0b6-c0042e92a846",
-              "destination_block": "5457ea5d-fbc6-531c-a518-ba6718028972",
+              "uuid": "f2e03d86-bcff-4915-a13b-6060b95a52a8",
+              "destination_block": "2f862525-e940-5b83-9741-9f808824d217",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -921,7 +935,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -930,7 +944,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 523
+                        "line": 529
                       },
                       "type": "expression"
                     },
@@ -949,7 +963,7 @@
             "value": "max_score"
           },
           "tags": [],
-          "uuid": "5457ea5d-fbc6-531c-a518-ba6718028972",
+          "uuid": "2f862525-e940-5b83-9741-9f808824d217",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -962,8 +976,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "e29844e3-1877-4e30-8938-d2ad3ceed034",
-              "destination_block": "989bd964-ad1d-5f1d-ad37-e7d737da4e3c",
+              "uuid": "c4b56a35-8451-4874-856b-5f7259117778",
+              "destination_block": "97855685-88b1-548a-a237-3c8f97c452bf",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -978,7 +992,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -986,7 +1000,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 524
+                        "line": 530
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -1027,7 +1041,7 @@
             "cache_ttl": 60000
           },
           "tags": [],
-          "uuid": "989bd964-ad1d-5f1d-ad37-e7d737da4e3c",
+          "uuid": "97855685-88b1-548a-a237-3c8f97c452bf",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1040,8 +1054,8 @@
               "name": "response",
               "config": {},
               "test": "",
-              "uuid": "5bb8f2ae-9201-41b5-a501-2675de8dc3d8",
-              "destination_block": "a7d59378-242b-5780-b365-8bcbf20dbffc",
+              "uuid": "96369d4e-3c8f-4279-8888-43101a03b091",
+              "destination_block": "2849cb76-5f75-591a-82aa-29066561e459",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1056,7 +1070,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -1064,7 +1078,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 526
+                        "line": 532
                       },
                       "type": "webhook",
                       "webhook": {}
@@ -1082,7 +1096,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a7d59378-242b-5780-b365-8bcbf20dbffc",
+          "uuid": "2849cb76-5f75-591a-82aa-29066561e459",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1095,8 +1109,8 @@
               "name": "response.body.body.text.value.message",
               "config": {},
               "test": "",
-              "uuid": "5af35504-fcc0-4126-bcfe-2b1c32ccf871",
-              "destination_block": "5365519d-0aad-5beb-9852-eac07ae410f7",
+              "uuid": "352b4a4f-c41c-40c1-91d4-5292e7356c52",
+              "destination_block": "8fa96d09-76d4-5f69-955b-26ed72909fd8",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1111,7 +1125,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -1120,7 +1134,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 539
+                        "line": 545
                       },
                       "type": "expression"
                     },
@@ -1136,10 +1150,10 @@
           "name": "display_end_page_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "21513e76-197c-44bd-ae76-a8bdc7c9942c"
+            "prompt": "70b7ef96-c0a3-47f5-a484-97033504afb7"
           },
           "tags": [],
-          "uuid": "5365519d-0aad-5beb-9852-eac07ae410f7",
+          "uuid": "8fa96d09-76d4-5f69-955b-26ed72909fd8",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1152,7 +1166,7 @@
               "name": "display_end_page_text",
               "config": {},
               "test": "",
-              "uuid": "19d2cb9f-458e-4ffd-9a72-7a6da3f96d0e",
+              "uuid": "395a2777-dfe2-4909-92da-72f648d9fc09",
               "destination_block": null,
               "semantic_label": "",
               "vendor_metadata": {}
@@ -1168,7 +1182,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 520
+                        "line": 526
                       },
                       "name": "DisplayEndPage",
                       "uuid": "e8288a8a-72ae-50b8-9ffe-80fdf0569447"
@@ -1176,7 +1190,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 540
+                        "line": 546
                       },
                       "text": {},
                       "type": "text"
@@ -1194,7 +1208,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "27e3a016-dc6d-5dee-be50-73ce053ac14f",
+          "uuid": "073e9c15-ed8c-5acc-89e9-19821f6567b4",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1207,7 +1221,7 @@
               "name": "answer_num + 1",
               "config": {},
               "test": "",
-              "uuid": "b51a4661-b438-43e3-be55-83f8bef17407",
+              "uuid": "fc039d79-838d-40bb-8b83-24d3f9a7b818",
               "destination_block": "5b652a56-c71a-5582-83f8-55b39072e60a",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -1223,7 +1237,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 380
+                        "line": 386
                       },
                       "name": "MultiselectResponseNo",
                       "uuid": "37a73151-bebf-5292-8912-20abd8f756c4"
@@ -1232,7 +1246,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 381
+                        "line": 387
                       },
                       "type": "expression"
                     },
@@ -1249,7 +1263,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "3de01a2b-e5e2-51de-9941-60540411763c",
+          "uuid": "bbfd8bdc-32ee-5348-9ea8-7efd4f37cba0",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1262,8 +1276,8 @@
               "name": "find(question.answers, &(&1.answer == answer_text))",
               "config": {},
               "test": "",
-              "uuid": "efd49b58-c764-4094-a3bc-c5dd4cf160a0",
-              "destination_block": "0fa4edf8-b2b8-5991-ba01-1d3599fb5dd5",
+              "uuid": "a27c2cba-6faf-4556-a9bd-fb7f73b70193",
+              "destination_block": "5bd7dcf5-1055-5c2f-87db-534ac94c1c47",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1278,7 +1292,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 364
+                        "line": 370
                       },
                       "name": "MultiselectResponseYes",
                       "uuid": "0ec16d81-7463-507b-afb2-0bc197fd2e4b"
@@ -1287,7 +1301,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 366
+                        "line": 372
                       },
                       "type": "expression"
                     },
@@ -1304,7 +1318,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "0fa4edf8-b2b8-5991-ba01-1d3599fb5dd5",
+          "uuid": "5bd7dcf5-1055-5c2f-87db-534ac94c1c47",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1317,8 +1331,8 @@
               "name": "answer.semantic_id",
               "config": {},
               "test": "",
-              "uuid": "25619120-e783-4792-ad74-857182dc5503",
-              "destination_block": "819c023b-307a-5edf-8645-dcb61b49c019",
+              "uuid": "8520d958-617f-448c-aa3d-18487323203f",
+              "destination_block": "dc2b456f-1859-50ba-92e9-01c541de5613",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1333,7 +1347,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 364
+                        "line": 370
                       },
                       "name": "MultiselectResponseYes",
                       "uuid": "0ec16d81-7463-507b-afb2-0bc197fd2e4b"
@@ -1342,7 +1356,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 367
+                        "line": 373
                       },
                       "type": "expression"
                     },
@@ -1359,7 +1373,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "819c023b-307a-5edf-8645-dcb61b49c019",
+          "uuid": "dc2b456f-1859-50ba-92e9-01c541de5613",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1372,8 +1386,8 @@
               "name": "score + answer.score",
               "config": {},
               "test": "",
-              "uuid": "150d836d-9e78-47d7-abf1-a5823b876b3e",
-              "destination_block": "71e51ada-593b-50ed-ae4c-5d43bde81094",
+              "uuid": "75f79cbd-e734-4c4a-9a23-85e66072beee",
+              "destination_block": "9bb1c53c-98fa-5117-9beb-c48a34ed8651",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1388,7 +1402,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 364
+                        "line": 370
                       },
                       "name": "MultiselectResponseYes",
                       "uuid": "0ec16d81-7463-507b-afb2-0bc197fd2e4b"
@@ -1397,7 +1411,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 368
+                        "line": 374
                       },
                       "type": "expression"
                     },
@@ -1413,10 +1427,10 @@
           "name": "multiselect_response_yes_log",
           "type": "Core.Log",
           "config": {
-            "message": "4ff25214-fccb-4161-b135-9580b142c215"
+            "message": "bf4f857d-33fd-4e64-817c-b23c4529abdd"
           },
           "tags": [],
-          "uuid": "71e51ada-593b-50ed-ae4c-5d43bde81094",
+          "uuid": "9bb1c53c-98fa-5117-9beb-c48a34ed8651",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1429,8 +1443,8 @@
               "name": "multiselect_response_yes_log",
               "config": {},
               "test": "",
-              "uuid": "4e6d6d28-e9e3-46ab-ae73-f6edc821a5b5",
-              "destination_block": "de3a946c-ecad-5f65-b27b-9fb012549c36",
+              "uuid": "b7839844-3597-4c57-b25d-f094951c2bee",
+              "destination_block": "629e7ef7-5cd8-5519-9a48-8d27bc55f92c",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1445,7 +1459,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 364
+                        "line": 370
                       },
                       "name": "MultiselectResponseYes",
                       "uuid": "0ec16d81-7463-507b-afb2-0bc197fd2e4b"
@@ -1454,7 +1468,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 369
+                        "line": 375
                       },
                       "type": "log"
                     },
@@ -1471,7 +1485,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "de3a946c-ecad-5f65-b27b-9fb012549c36",
+          "uuid": "629e7ef7-5cd8-5519-9a48-8d27bc55f92c",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1484,8 +1498,8 @@
               "name": "answer_num + 1",
               "config": {},
               "test": "",
-              "uuid": "e454e1a5-d019-4133-a020-f2cf4bdacba5",
-              "destination_block": "bbfd8bdc-32ee-5348-9ea8-7efd4f37cba0",
+              "uuid": "b6ced26b-0d33-4212-8495-8f84e97c2273",
+              "destination_block": "c9287754-56f1-5cf8-b544-516eab7b7369",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1500,7 +1514,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 364
+                        "line": 370
                       },
                       "name": "MultiselectResponseYes",
                       "uuid": "0ec16d81-7463-507b-afb2-0bc197fd2e4b"
@@ -1509,7 +1523,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 370
+                        "line": 376
                       },
                       "type": "expression"
                     },
@@ -1526,7 +1540,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "bbfd8bdc-32ee-5348-9ea8-7efd4f37cba0",
+          "uuid": "c9287754-56f1-5cf8-b544-516eab7b7369",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1539,7 +1553,7 @@
               "name": "if(is_nil_or_empty(multiselect_answer), \"@semantic_id\", concatenate(multiselect_answer, \",\", \"@semantic_id\"))",
               "config": {},
               "test": "",
-              "uuid": "a86d6747-d710-4c43-9bfb-15697e5de5c6",
+              "uuid": "2d577334-7332-4575-8e65-edd3e7a975fd",
               "destination_block": "5b652a56-c71a-5582-83f8-55b39072e60a",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -1555,7 +1569,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 364
+                        "line": 370
                       },
                       "name": "MultiselectResponseYes",
                       "uuid": "0ec16d81-7463-507b-afb2-0bc197fd2e4b"
@@ -1564,7 +1578,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 372
+                        "line": 378
                       },
                       "type": "expression"
                     },
@@ -1589,8 +1603,8 @@
               "name": "Exit for multiselect_error_case_condition_0",
               "config": {},
               "test": "has_all_members(keywords, [question_response])",
-              "uuid": "7a4998a5-fc92-483c-b474-cb9e3d0b32a1",
-              "destination_block": "d0ea1e23-9017-5783-8b4b-87a600600b58",
+              "uuid": "52fcec2c-fd23-4b69-9e2f-63d062b5af56",
+              "destination_block": "1497e388-eed7-5778-851c-b8ae3a1e716e",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -1599,8 +1613,8 @@
               "name": "Exit for multiselect_error_case_condition_1",
               "config": {},
               "test": "lower(question_response) == \"skip\"",
-              "uuid": "4c520593-6fb1-49d8-a3f7-cb243463f938",
-              "destination_block": "ad2aab8b-e2ca-59c2-9170-29c826a54bfa",
+              "uuid": "c5463573-3806-4e81-bdeb-889a200628de",
+              "destination_block": "79cb8585-5898-5d7c-89ff-44c3e5779bce",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -1609,8 +1623,8 @@
               "name": "Exit for multiselect_error_case_condition_2",
               "config": {},
               "test": null,
-              "uuid": "30f0c539-227e-4bee-bd84-fcc92db625ba",
-              "destination_block": "59df040a-93bf-56e1-81e7-ff7dc194c1c4",
+              "uuid": "0645f528-b05c-4505-aa44-f2a5694f6bb4",
+              "destination_block": "8b7777de-9989-5d92-8b50-b6eb4fc7e9c0",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -1624,7 +1638,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "59df040a-93bf-56e1-81e7-ff7dc194c1c4",
+          "uuid": "8b7777de-9989-5d92-8b50-b6eb4fc7e9c0",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1637,8 +1651,8 @@
               "name": "if(is_nil_or_empty(question.error), assessment_data.generic_error, question.error)",
               "config": {},
               "test": "",
-              "uuid": "97e458f1-507b-4a27-860e-ad39ec42722e",
-              "destination_block": "1f7609ea-d44a-5edf-95ee-d10b689c2d5e",
+              "uuid": "63ab4058-0d32-4be3-999a-0c2ccb9b1abd",
+              "destination_block": "2daac5a2-8578-5b4b-a7b0-da494fa20b90",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1653,7 +1667,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 355
+                        "line": 361
                       },
                       "name": "MultiselectError",
                       "uuid": "2c1669e6-0fce-5042-9d76-b42e1f5ee953"
@@ -1662,7 +1676,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 357
+                        "line": 363
                       },
                       "type": "expression"
                     },
@@ -1678,10 +1692,10 @@
           "name": "multiselect_error_case_condition_2_log",
           "type": "Core.Log",
           "config": {
-            "message": "47cb90b8-f97d-47ed-b1f6-8d582f9e5d4d"
+            "message": "93a8fe5c-b3a2-445f-a623-c1cd6b87b975"
           },
           "tags": [],
-          "uuid": "1f7609ea-d44a-5edf-95ee-d10b689c2d5e",
+          "uuid": "2daac5a2-8578-5b4b-a7b0-da494fa20b90",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1694,8 +1708,8 @@
               "name": "multiselect_error_case_condition_2_log",
               "config": {},
               "test": "",
-              "uuid": "c0ca36a6-5dd9-418a-882e-490c19a50c82",
-              "destination_block": "47c677eb-5e49-5f9f-b3cc-2323c11081f3",
+              "uuid": "182a706c-b721-4ec5-907c-b0065fa7a3a4",
+              "destination_block": "c9ae711c-69fd-5b43-bf19-30c0a15b24ff",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1710,7 +1724,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 355
+                        "line": 361
                       },
                       "name": "MultiselectError",
                       "uuid": "2c1669e6-0fce-5042-9d76-b42e1f5ee953"
@@ -1719,7 +1733,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 358
+                        "line": 364
                       },
                       "type": "log"
                     },
@@ -1735,10 +1749,10 @@
           "name": "multiselect_error_case_condition_2_log",
           "type": "Core.Log",
           "config": {
-            "message": "bab7e27e-bf0f-472b-ab9b-f51b8306b661"
+            "message": "f334b3a7-3e52-4e36-ae4c-e81efcb1b4c8"
           },
           "tags": [],
-          "uuid": "47c677eb-5e49-5f9f-b3cc-2323c11081f3",
+          "uuid": "c9ae711c-69fd-5b43-bf19-30c0a15b24ff",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1751,8 +1765,8 @@
               "name": "multiselect_error_case_condition_2_log",
               "config": {},
               "test": "",
-              "uuid": "3f573c35-ee31-4e13-9e9c-2344f304cd67",
-              "destination_block": "39e45760-2039-516e-aefb-d30be0417d3f",
+              "uuid": "91f0f3a4-7c9b-493f-a48b-e3249a7a9d2f",
+              "destination_block": "7d3bbee2-b7e2-5015-89d0-629634cec778",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1767,7 +1781,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 355
+                        "line": 361
                       },
                       "name": "MultiselectError",
                       "uuid": "2c1669e6-0fce-5042-9d76-b42e1f5ee953"
@@ -1776,7 +1790,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 359
+                        "line": 365
                       },
                       "type": "log"
                     },
@@ -1792,10 +1806,10 @@
           "name": "multiselect_error_case_condition_2_log",
           "type": "Core.Log",
           "config": {
-            "message": "041bf2b3-f9e5-44d3-9eb0-a29ed6982385"
+            "message": "26394d94-90d4-4a6d-9250-025c686c1aa7"
           },
           "tags": [],
-          "uuid": "39e45760-2039-516e-aefb-d30be0417d3f",
+          "uuid": "7d3bbee2-b7e2-5015-89d0-629634cec778",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1808,8 +1822,8 @@
               "name": "multiselect_error_case_condition_2_log",
               "config": {},
               "test": "",
-              "uuid": "822003e3-5e6e-497b-9d59-05ea78af1f28",
-              "destination_block": "194c64b5-50de-50e0-9e30-de070c56f37c",
+              "uuid": "70935a55-932d-4c2d-80b7-7d8101317190",
+              "destination_block": "ed829df2-9f7b-5220-aa4e-7e811c0f0163",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1824,7 +1838,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 355
+                        "line": 361
                       },
                       "name": "MultiselectError",
                       "uuid": "2c1669e6-0fce-5042-9d76-b42e1f5ee953"
@@ -1833,7 +1847,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 360
+                        "line": 366
                       },
                       "type": "log"
                     },
@@ -1849,10 +1863,10 @@
           "name": "multiselect_error_case_condition_2_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "28ad428e-6dfd-4abf-b2bd-79e2634d57a3"
+            "prompt": "08ae260c-23d3-43b0-a600-59ed1c93ec57"
           },
           "tags": [],
-          "uuid": "194c64b5-50de-50e0-9e30-de070c56f37c",
+          "uuid": "ed829df2-9f7b-5220-aa4e-7e811c0f0163",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1865,8 +1879,8 @@
               "name": "Default exit to \"DisplayMultiselectAnswer\"",
               "config": {},
               "test": "",
-              "uuid": "32faecdd-a299-4454-8a75-a8ea636a44fa",
-              "destination_block": "1fa9bf72-8fa3-5288-9caa-e5be1b78ec5a",
+              "uuid": "3df676d3-d038-4335-8c01-23c20590b28e",
+              "destination_block": "152de0b6-284f-5619-b7a4-c2af42a008b0",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1881,7 +1895,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 355
+                        "line": 361
                       },
                       "name": "MultiselectError",
                       "uuid": "2c1669e6-0fce-5042-9d76-b42e1f5ee953"
@@ -1889,7 +1903,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 361
+                        "line": 367
                       },
                       "text": {},
                       "type": "text"
@@ -1907,7 +1921,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "ad2aab8b-e2ca-59c2-9170-29c826a54bfa",
+          "uuid": "79cb8585-5898-5d7c-89ff-44c3e5779bce",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1920,8 +1934,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"question_num\")",
               "config": {},
               "test": "",
-              "uuid": "2006d722-7e4f-4e73-8fcd-a2ab7320b6d7",
-              "destination_block": "8e03c620-205b-52e4-a9ff-000221bcd263",
+              "uuid": "3addfc68-17d7-4d86-bd95-b2714102be19",
+              "destination_block": "871c2dab-42ce-5c76-9e2f-ad57d25a53d6",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1936,7 +1950,7 @@
                       "condition": "lower(@question_response) == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 333
+                        "line": 339
                       },
                       "name": "MultiselectError",
                       "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
@@ -1945,7 +1959,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 339
+                        "line": 345
                       },
                       "type": "expression"
                     },
@@ -1964,7 +1978,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "8e03c620-205b-52e4-a9ff-000221bcd263",
+          "uuid": "871c2dab-42ce-5c76-9e2f-ad57d25a53d6",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -1977,8 +1991,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "78385901-0199-4b10-94c4-a924c396eaa4",
-              "destination_block": "fdffa06e-9450-578a-8baf-6b1a573d3307",
+              "uuid": "d2f9b11a-c89f-42fa-a74b-493b3aed9fbe",
+              "destination_block": "bda7f184-7baa-506e-8361-c7c4807b7eba",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -1993,7 +2007,7 @@
                       "condition": "lower(@question_response) == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 333
+                        "line": 339
                       },
                       "name": "MultiselectError",
                       "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
@@ -2001,7 +2015,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 340
+                        "line": 346
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -2019,7 +2033,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "fdffa06e-9450-578a-8baf-6b1a573d3307",
+          "uuid": "bda7f184-7baa-506e-8361-c7c4807b7eba",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2032,8 +2046,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "78d87f28-1954-42bd-a966-b9cb9ceff896",
-              "destination_block": "3b40f74e-a859-5474-bfe1-ab950baa7768",
+              "uuid": "e8330800-fc98-4e96-a345-48711892b4d4",
+              "destination_block": "f37d4b18-55f7-55a1-a2be-0ed17bb62085",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2048,229 +2062,7 @@
                       "condition": "lower(@question_response) == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 333
-                      },
-                      "name": "MultiselectError",
-                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 341
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "result_tag",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "3b40f74e-a859-5474-bfe1-ab950baa7768",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
-              "config": {},
-              "test": "",
-              "uuid": "756a7ad4-f07e-4302-9f8a-0d9ec7668f9d",
-              "destination_block": "8eccfd57-98d9-5d83-8d01-fc7794581e53",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "lower(@question_response) == \"skip\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 333
-                      },
-                      "name": "MultiselectError",
-                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 342
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "@result_tag",
-          "type": "Core.Output",
-          "config": {
-            "value": "\"skip\""
-          },
-          "tags": [],
-          "uuid": "8eccfd57-98d9-5d83-8d01-fc7794581e53",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "@result_tag",
-              "config": {},
-              "test": "",
-              "uuid": "aa2d12b4-7d12-4e99-bea3-dea8273cc5ab",
-              "destination_block": "79cb8585-5898-5d7c-89ff-44c3e5779bce",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "lower(@question_response) == \"skip\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 333
-                      },
-                      "name": "MultiselectError",
-                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
-                    },
-                    "card_item": {
-                      "meta": {
-                        "column": 3,
-                        "line": 343
-                      },
-                      "type": "write_result",
-                      "write_result": {}
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "skip_count",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "79cb8585-5898-5d7c-89ff-44c3e5779bce",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "skip_count + 1",
-              "config": {},
-              "test": "",
-              "uuid": "45f24762-a5a8-45b9-a70e-82006a7fb269",
-              "destination_block": "bda7f184-7baa-506e-8361-c7c4807b7eba",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "lower(@question_response) == \"skip\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 333
-                      },
-                      "name": "MultiselectError",
-                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 345
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "max_score",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "bda7f184-7baa-506e-8361-c7c4807b7eba",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "max_score - max_question_score",
-              "config": {},
-              "test": "",
-              "uuid": "ed6e2867-90a2-4425-9901-a5f534361493",
-              "destination_block": "70c87dc5-b7d2-53d5-8011-c4174ca7aa72",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "lower(@question_response) == \"skip\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 333
+                        "line": 339
                       },
                       "name": "MultiselectError",
                       "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
@@ -2292,13 +2084,11 @@
         },
         {
           "label": null,
-          "name": "multiselect_error_case_condition_1_log",
-          "type": "Core.Log",
-          "config": {
-            "message": "28cd58d4-3c68-4a36-bbab-7ae65844e801"
-          },
+          "name": "result_tag",
+          "type": "Core.Case",
+          "config": {},
           "tags": [],
-          "uuid": "70c87dc5-b7d2-53d5-8011-c4174ca7aa72",
+          "uuid": "f37d4b18-55f7-55a1-a2be-0ed17bb62085",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2308,11 +2098,11 @@
           "exits": [
             {
               "default": true,
-              "name": "multiselect_error_case_condition_1_log",
+              "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
               "config": {},
               "test": "",
-              "uuid": "5f9ee2ed-6726-4e54-a11b-dd7ef0f21406",
-              "destination_block": "991d13b3-3bc1-5521-8725-8850fed41732",
+              "uuid": "7152da98-bee7-48bc-b9aa-6076a7235035",
+              "destination_block": "31ea10a1-842a-5365-af07-ea0b42fc0706",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2327,7 +2117,231 @@
                       "condition": "lower(@question_response) == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 333
+                        "line": 339
+                      },
+                      "name": "MultiselectError",
+                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 348
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "@result_tag",
+          "type": "Core.Output",
+          "config": {
+            "value": "\"skip\""
+          },
+          "tags": [],
+          "uuid": "31ea10a1-842a-5365-af07-ea0b42fc0706",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "@result_tag",
+              "config": {},
+              "test": "",
+              "uuid": "1fe2edf3-f4a9-44e7-a00f-584956a52ff0",
+              "destination_block": "6ccc2703-8b97-5a53-989c-6e441969c5db",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "lower(@question_response) == \"skip\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 339
+                      },
+                      "name": "MultiselectError",
+                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 3,
+                        "line": 349
+                      },
+                      "type": "write_result",
+                      "write_result": {}
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "skip_count",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "6ccc2703-8b97-5a53-989c-6e441969c5db",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "skip_count + 1",
+              "config": {},
+              "test": "",
+              "uuid": "8dc1f3a1-f19f-4cf8-8959-a0630c590089",
+              "destination_block": "3f91e745-39db-58d8-a04a-34f23076144d",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "lower(@question_response) == \"skip\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 339
+                      },
+                      "name": "MultiselectError",
+                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 351
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "max_score",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "3f91e745-39db-58d8-a04a-34f23076144d",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "max_score - max_question_score",
+              "config": {},
+              "test": "",
+              "uuid": "d0ecb0c8-96e1-4b97-b12d-e848e8f4f42f",
+              "destination_block": "6b8c5d16-dfe6-5d5c-88a3-9cd36e2b6fa4",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "lower(@question_response) == \"skip\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 339
+                      },
+                      "name": "MultiselectError",
+                      "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 353
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "multiselect_error_case_condition_1_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "e3b88db2-f9ef-4baf-966f-939406ccc8d1"
+          },
+          "tags": [],
+          "uuid": "6b8c5d16-dfe6-5d5c-88a3-9cd36e2b6fa4",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "multiselect_error_case_condition_1_log",
+              "config": {},
+              "test": "",
+              "uuid": "1c670d3f-4478-4add-9ed1-b06ecec6495a",
+              "destination_block": "b2e9f35a-0104-5fb1-bab1-7076aea4b295",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "lower(@question_response) == \"skip\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 339
                       },
                       "name": "MultiselectError",
                       "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
@@ -2336,7 +2350,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 349
+                        "line": 355
                       },
                       "type": "log"
                     },
@@ -2352,10 +2366,10 @@
           "name": "multiselect_error_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "58c52a5b-9ba4-4cd6-98f5-da5f56d64509"
+            "message": "94393505-0de7-4065-8ccf-495818280f82"
           },
           "tags": [],
-          "uuid": "991d13b3-3bc1-5521-8725-8850fed41732",
+          "uuid": "b2e9f35a-0104-5fb1-bab1-7076aea4b295",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2368,8 +2382,8 @@
               "name": "multiselect_error_case_condition_1_log",
               "config": {},
               "test": "",
-              "uuid": "f98a2042-0051-499f-9fd6-45bd8a5ba19d",
-              "destination_block": "f4d46817-b118-5dc1-95d3-a37b9fc37270",
+              "uuid": "a34ddb42-c819-4f00-b432-ced60764bddc",
+              "destination_block": "ce59d0ef-58d9-5f71-a7dd-dcf697901a63",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2384,7 +2398,7 @@
                       "condition": "lower(@question_response) == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 333
+                        "line": 339
                       },
                       "name": "MultiselectError",
                       "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
@@ -2393,7 +2407,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 350
+                        "line": 356
                       },
                       "type": "log"
                     },
@@ -2410,7 +2424,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "f4d46817-b118-5dc1-95d3-a37b9fc37270",
+          "uuid": "ce59d0ef-58d9-5f71-a7dd-dcf697901a63",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2423,7 +2437,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "90c9d845-fc28-4fd5-a94c-cbc2123e46e5",
+              "uuid": "b8d3b602-726a-48c7-8614-3fa0388375fc",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -2439,7 +2453,7 @@
                       "condition": "lower(@question_response) == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 333
+                        "line": 339
                       },
                       "name": "MultiselectError",
                       "uuid": "35a8a2b3-8382-5b43-bb9a-5bebe557f012"
@@ -2448,7 +2462,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 352
+                        "line": 358
                       },
                       "type": "expression"
                     },
@@ -2465,7 +2479,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "d0ea1e23-9017-5783-8b4b-87a600600b58",
+          "uuid": "1497e388-eed7-5778-851c-b8ae3a1e716e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2478,8 +2492,8 @@
               "name": "if(is_nil_or_empty(question.explainer), \"*Explainer:* There's no explainer for this.\", concatenate(\"*Explainer:*\", \" \", question.explainer))",
               "config": {},
               "test": "",
-              "uuid": "b4937fec-31c3-40a3-befe-1199d5929bc4",
-              "destination_block": "7b239ca0-af3d-5f93-ada0-5ea5ccb302f6",
+              "uuid": "bd623088-fb17-4d79-be0e-f0059e8fef19",
+              "destination_block": "490a0708-c348-56cb-b819-2c314eeef899",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2494,7 +2508,7 @@
                       "condition": "has_all_members(keywords, [@question_response])",
                       "meta": {
                         "column": 1,
-                        "line": 321
+                        "line": 327
                       },
                       "name": "MultiselectError",
                       "uuid": "205afeb9-04e6-5b84-8102-bb4631a81a99"
@@ -2503,7 +2517,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 323
+                        "line": 329
                       },
                       "type": "expression"
                     },
@@ -2519,10 +2533,10 @@
           "name": "multiselect_error_case_condition_0_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "a8d55d64-1d53-45bb-83a2-d87831a33da1"
+            "prompt": "249e2926-967b-41ac-9977-9f381dceb2f1"
           },
           "tags": [],
-          "uuid": "7b239ca0-af3d-5f93-ada0-5ea5ccb302f6",
+          "uuid": "490a0708-c348-56cb-b819-2c314eeef899",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2535,8 +2549,8 @@
               "name": "Default exit to \"DisplayMultiselectAnswer\"",
               "config": {},
               "test": "",
-              "uuid": "23a45731-c152-4c71-87f9-addbf01aa81f",
-              "destination_block": "1fa9bf72-8fa3-5288-9caa-e5be1b78ec5a",
+              "uuid": "7137ab39-ddd5-4379-af90-6ea23f0000d5",
+              "destination_block": "152de0b6-284f-5619-b7a4-c2af42a008b0",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2551,7 +2565,7 @@
                       "condition": "has_all_members(keywords, [@question_response])",
                       "meta": {
                         "column": 1,
-                        "line": 321
+                        "line": 327
                       },
                       "name": "MultiselectError",
                       "uuid": "205afeb9-04e6-5b84-8102-bb4631a81a99"
@@ -2559,7 +2573,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 330
+                        "line": 336
                       },
                       "text": {},
                       "type": "text"
@@ -2585,8 +2599,8 @@
               "name": "Exit for check_end_multiselect_case_condition_0",
               "config": {},
               "test": "and(questions[question_num].question_type == \"multiselect_question\", answer_num == count(questions[question_num].answers))",
-              "uuid": "7ceca8e8-85db-4132-96b7-349dcffb04e6",
-              "destination_block": "0614bd2a-f655-59eb-a290-6c1d1ef7fadd",
+              "uuid": "7f458e13-0754-427b-a839-15f5e6827a47",
+              "destination_block": "dcff2959-11a0-5e02-a276-f33edc5bfb53",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -2595,8 +2609,8 @@
               "name": "Exit for check_end_multiselect_case_condition_1",
               "config": {},
               "test": null,
-              "uuid": "dcc3fb1f-3411-4dc1-ad62-ec91d44b578e",
-              "destination_block": "827471e4-8ba2-5e3d-932f-3554bc2c7a9e",
+              "uuid": "acbc97e5-267b-43c4-a93d-1774d6ace987",
+              "destination_block": "e01fb3c6-edd5-5adc-8626-1405530fc28e",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -2610,7 +2624,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "827471e4-8ba2-5e3d-932f-3554bc2c7a9e",
+          "uuid": "e01fb3c6-edd5-5adc-8626-1405530fc28e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2623,8 +2637,8 @@
               "name": "Exit for DisplayMultiselectAnswer",
               "config": {},
               "test": "true",
-              "uuid": "fa15d519-47ec-4020-ad6d-2023b9790435",
-              "destination_block": "1fa9bf72-8fa3-5288-9caa-e5be1b78ec5a",
+              "uuid": "65d156c5-08d7-4349-81de-34934ec0c168",
+              "destination_block": "152de0b6-284f-5619-b7a4-c2af42a008b0",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -2639,7 +2653,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 292
+                        "line": 298
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "0528042f-dc4f-5288-8a7b-f0cb2e2fe84f"
@@ -2647,7 +2661,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 293
+                        "line": 299
                       },
                       "then": {},
                       "type": "then"
@@ -2665,7 +2679,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "0614bd2a-f655-59eb-a290-6c1d1ef7fadd",
+          "uuid": "dcff2959-11a0-5e02-a276-f33edc5bfb53",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2678,8 +2692,8 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "e4290275-fa0a-448b-9be7-6c0733337f6a",
-              "destination_block": "7b6814af-8f0d-54e8-9e61-663973946aef",
+              "uuid": "2730a846-2094-456c-b2b9-6d84bea03af3",
+              "destination_block": "a3e3a349-6c19-538d-ad11-f47e230abf0e",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2694,7 +2708,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -2703,7 +2717,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 282
+                        "line": 288
                       },
                       "type": "expression"
                     },
@@ -2720,7 +2734,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "7b6814af-8f0d-54e8-9e61-663973946aef",
+          "uuid": "a3e3a349-6c19-538d-ad11-f47e230abf0e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2733,8 +2747,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"question_num\")",
               "config": {},
               "test": "",
-              "uuid": "e418d037-f178-4552-b469-aff77123ac3e",
-              "destination_block": "aa5ec980-d530-5f46-998e-d7a500be9188",
+              "uuid": "d1254d41-731c-4075-8a51-f467afce3fff",
+              "destination_block": "e5fb67d1-358a-565c-b265-71e0dd64bef3",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2749,7 +2763,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -2758,7 +2772,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 284
+                        "line": 290
                       },
                       "type": "expression"
                     },
@@ -2777,7 +2791,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "aa5ec980-d530-5f46-998e-d7a500be9188",
+          "uuid": "e5fb67d1-358a-565c-b265-71e0dd64bef3",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2790,8 +2804,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "d18504ae-ea36-48a1-9285-3976c9c53b14",
-              "destination_block": "3b887268-82b1-5f11-8db2-c661785386ac",
+              "uuid": "7336511e-30e1-4ab9-8239-1cba87b02681",
+              "destination_block": "c6769323-8688-58e3-8681-222284a09cc8",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2806,7 +2820,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -2814,7 +2828,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 285
+                        "line": 291
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -2832,7 +2846,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "3b887268-82b1-5f11-8db2-c661785386ac",
+          "uuid": "c6769323-8688-58e3-8681-222284a09cc8",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2845,8 +2859,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "756a9a1c-8002-486e-8d0c-b54328445f54",
-              "destination_block": "261566d4-fe04-5d5c-9d4c-4c02cc5e7dcd",
+              "uuid": "ad5baec8-a9b6-47fc-afb2-0b55bbf84a9f",
+              "destination_block": "cb3e06f6-d3ff-5145-9496-a7ba7b645305",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2861,7 +2875,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -2870,7 +2884,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 286
+                        "line": 292
                       },
                       "type": "expression"
                     },
@@ -2887,7 +2901,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "261566d4-fe04-5d5c-9d4c-4c02cc5e7dcd",
+          "uuid": "cb3e06f6-d3ff-5145-9496-a7ba7b645305",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2900,8 +2914,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
               "config": {},
               "test": "",
-              "uuid": "f6c267c7-cf93-4a05-9fc6-6b757e6b8fd7",
-              "destination_block": "6dc7b744-d9b3-5dd8-ae9f-0955705b616d",
+              "uuid": "574886e2-730e-4f11-8a24-e08af8d884e4",
+              "destination_block": "5b00346f-c6ed-5b44-b2d8-0f428bcb23bd",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2916,7 +2930,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -2925,7 +2939,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 287
+                        "line": 293
                       },
                       "type": "expression"
                     },
@@ -2944,7 +2958,7 @@
             "value": "\"@multiselect_answer\""
           },
           "tags": [],
-          "uuid": "6dc7b744-d9b3-5dd8-ae9f-0955705b616d",
+          "uuid": "5b00346f-c6ed-5b44-b2d8-0f428bcb23bd",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -2957,8 +2971,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "cb29fa7d-1c01-4049-92b9-1727138300fc",
-              "destination_block": "4d1eadba-2491-53d0-ab3f-c413e595a624",
+              "uuid": "7b254243-70da-4529-bfb0-f0450c55dea7",
+              "destination_block": "d9c3426a-9470-5922-8a9b-46a751a115d9",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -2973,7 +2987,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -2981,7 +2995,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 288
+                        "line": 294
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -2998,10 +3012,10 @@
           "name": "check_end_multiselect_case_condition_0_log",
           "type": "Core.Log",
           "config": {
-            "message": "1f8eae2e-7658-4d14-a63f-0868a7a4c32b"
+            "message": "e717033c-9c9b-4e34-8b09-04b31a6d6a7c"
           },
           "tags": [],
-          "uuid": "4d1eadba-2491-53d0-ab3f-c413e595a624",
+          "uuid": "d9c3426a-9470-5922-8a9b-46a751a115d9",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3014,7 +3028,7 @@
               "name": "Default exit to \"CheckEnd\"",
               "config": {},
               "test": "",
-              "uuid": "bd7d6483-2e40-4a69-856c-9268e9fb21a7",
+              "uuid": "57e52d9d-44d3-4448-b3b0-f18adafdbabf",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -3030,7 +3044,7 @@
                       "condition": "questions[question_num].question_type == \"multiselect_question\" and answer_num == count(questions[question_num].answers)",
                       "meta": {
                         "column": 1,
-                        "line": 278
+                        "line": 284
                       },
                       "name": "CheckEndMultiselect",
                       "uuid": "5b652a56-c71a-5582-83f8-55b39072e60a"
@@ -3039,7 +3053,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 289
+                        "line": 295
                       },
                       "type": "log"
                     },
@@ -3064,7 +3078,7 @@
               "name": "Exit for validate_input_case_condition_0",
               "config": {},
               "test": "and(assertion == false, questions[question_num].question_type == \"year_of_birth_question\")",
-              "uuid": "0aa1a541-70b6-4ea6-a30c-69722f33e28c",
+              "uuid": "e7e2cf81-4ba0-44c8-979b-c8006be249ed",
               "destination_block": "6f683cc1-53c8-525e-9a3f-8cd7fb093df4",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -3074,18 +3088,28 @@
               "name": "Exit for validate_input_case_condition_1",
               "config": {},
               "test": "and(assertion == false, questions[question_num].question_type == \"integer_question\")",
-              "uuid": "952125bd-de77-4ba7-9d43-3a08b2f1d71d",
+              "uuid": "c8484b7f-1928-420d-8279-ce1bd4359351",
               "destination_block": "a0bca882-4926-5f6c-9bf7-8898930510c7",
               "semantic_label": null,
               "vendor_metadata": {}
             },
             {
-              "default": true,
+              "default": false,
               "name": "Exit for validate_input_case_condition_2",
               "config": {},
+              "test": "not(has_member(map(question.answers, & &1.answer), question_response))",
+              "uuid": "500095f1-6bd6-4e6c-a855-47d5142c8df4",
+              "destination_block": "573ad867-c169-5eeb-8571-df1c391d9006",
+              "semantic_label": null,
+              "vendor_metadata": {}
+            },
+            {
+              "default": true,
+              "name": "Exit for validate_input_case_condition_3",
+              "config": {},
               "test": null,
-              "uuid": "7751d366-2106-4734-9afe-8fff945dba92",
-              "destination_block": "e9ebf766-9651-588b-9f1d-a244f9ba9477",
+              "uuid": "fbd3a871-50d3-4c83-a91b-2799e296e5ad",
+              "destination_block": "0c9efb33-5e01-5bb8-9491-37c9705683c8",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -3095,13 +3119,13 @@
         },
         {
           "label": null,
-          "name": "validate_input_case_condition_2_log",
+          "name": "validate_input_case_condition_3_log",
           "type": "Core.Log",
           "config": {
-            "message": "99fb33ba-a2da-4416-8e55-e3c58851bd78"
+            "message": "3691f1f1-a350-43b5-8a22-ebf95462fbb0"
           },
           "tags": [],
-          "uuid": "e9ebf766-9651-588b-9f1d-a244f9ba9477",
+          "uuid": "0c9efb33-5e01-5bb8-9491-37c9705683c8",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3114,7 +3138,7 @@
               "name": "Default exit to \"QuestionResponse\"",
               "config": {},
               "test": "",
-              "uuid": "af817d78-bab5-4001-886d-6b7fc35bca8c",
+              "uuid": "cadb349a-4159-461c-878f-ed0dab7a27a0",
               "destination_block": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -3130,7 +3154,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 200
+                        "line": 206
                       },
                       "name": "ValidateInput",
                       "uuid": "1e9e49d4-5d52-5e1a-b9d3-c163d8998746"
@@ -3139,7 +3163,64 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 201
+                        "line": 207
+                      },
+                      "type": "log"
+                    },
+                    "index": 3
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "validate_input_case_condition_2_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "394d436d-253a-4b21-86e3-d8f76d9177a9"
+          },
+          "tags": [],
+          "uuid": "573ad867-c169-5eeb-8571-df1c391d9006",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "Default exit to \"QuestionError\"",
+              "config": {},
+              "test": "",
+              "uuid": "c71fa394-1a1d-42ab-896c-14b15df243a6",
+              "destination_block": "8691a3eb-668a-57bf-a075-7b30fd3ed174",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "not has_member(map(question.answers, & &1.answer), question_response)",
+                      "meta": {
+                        "column": 1,
+                        "line": 200
+                      },
+                      "name": "ValidateInput",
+                      "uuid": "7950363d-b130-5d7a-b9a6-ff5b6beb7a87"
+                    },
+                    "card_item": {
+                      "log": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 203
                       },
                       "type": "log"
                     },
@@ -3155,7 +3236,7 @@
           "name": "validate_input_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "346dc839-aef7-42ed-a30d-f38e96532d22"
+            "message": "d485ca81-bd3f-42c1-9dc6-e1633ad4aac9"
           },
           "tags": [],
           "uuid": "a0bca882-4926-5f6c-9bf7-8898930510c7",
@@ -3171,7 +3252,7 @@
               "name": "Default exit to \"QuestionError\"",
               "config": {},
               "test": "",
-              "uuid": "12100ef8-c9e5-472f-abe0-80fd3e861dfa",
+              "uuid": "cda13c75-7b60-431f-9093-a2992acd9893",
               "destination_block": "8691a3eb-668a-57bf-a075-7b30fd3ed174",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -3212,7 +3293,7 @@
           "name": "validate_input_case_condition_0_log",
           "type": "Core.Log",
           "config": {
-            "message": "c69aba8d-439f-4576-ae7a-0fac4cec3b52"
+            "message": "507a4402-0633-4d9a-9156-00d8546560c1"
           },
           "tags": [],
           "uuid": "6f683cc1-53c8-525e-9a3f-8cd7fb093df4",
@@ -3228,7 +3309,7 @@
               "name": "Default exit to \"QuestionError\"",
               "config": {},
               "test": "",
-              "uuid": "761dfcbb-4118-48e0-baaf-a0917d75fed1",
+              "uuid": "2f38d3a9-781b-4740-b68b-3db2a39e1704",
               "destination_block": "8691a3eb-668a-57bf-a075-7b30fd3ed174",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -3278,8 +3359,8 @@
               "name": "Exit for question_error_case_condition_0",
               "config": {},
               "test": "and(questions[question_num].question_type == \"integer_question\", question_response != lower(\"skip\"))",
-              "uuid": "8b0ac8a9-b78b-49a9-a708-64f04deee4e0",
-              "destination_block": "8942a297-cff4-507f-a1d8-c941bccc3dc6",
+              "uuid": "4d459634-bf64-44be-9465-7bc40422f4cc",
+              "destination_block": "f37a2c3e-563e-5965-886c-990bd1b2026a",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -3288,8 +3369,8 @@
               "name": "Exit for question_error_case_condition_1",
               "config": {},
               "test": "and(questions[question_num].question_type == \"year_of_birth_question\", question_response != lower(\"skip\"))",
-              "uuid": "d57f79c4-470c-43e7-b5f5-0e12b5e19207",
-              "destination_block": "1b8806f5-f420-512e-91f7-3d3c54acb546",
+              "uuid": "a2506450-44e8-4483-9f3f-766001814c21",
+              "destination_block": "7832657d-8591-5c25-ba77-cf77d46f1f45",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -3298,8 +3379,8 @@
               "name": "Exit for question_error_case_condition_2",
               "config": {},
               "test": "has_all_members(keywords, [question_response])",
-              "uuid": "f78bc3ae-65a8-4f16-91e2-f2587031cf56",
-              "destination_block": "ff6aa469-3707-53fe-bf4a-2512c7753e5d",
+              "uuid": "8e77d86b-98b0-4f98-8db0-236d2d3a49ae",
+              "destination_block": "6414e6fc-3de8-51c0-b68b-e4e0a52fb208",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -3308,8 +3389,8 @@
               "name": "Exit for question_error_case_condition_3",
               "config": {},
               "test": "question_response == lower(\"skip\")",
-              "uuid": "735e72c1-0673-4ff1-bfa4-39634ea465ea",
-              "destination_block": "21d6abe3-faf0-53c3-9de9-325d26b22872",
+              "uuid": "69bbf1b3-3fdd-4b2e-899a-6c5494234164",
+              "destination_block": "8e2ff029-ec98-5279-ace3-02332a6b0c98",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -3318,8 +3399,8 @@
               "name": "Exit for question_error_case_condition_4",
               "config": {},
               "test": null,
-              "uuid": "d430cbe7-8cb7-4be9-a6fc-0fe4af8a90fe",
-              "destination_block": "4d5a68a3-6321-5ba4-bc23-bbb5ef7b6951",
+              "uuid": "ff8c60da-c50b-4b31-b055-d2368972f8f5",
+              "destination_block": "bf10cb03-509d-567a-94dd-dfeabf356dfa",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -3333,7 +3414,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "4d5a68a3-6321-5ba4-bc23-bbb5ef7b6951",
+          "uuid": "bf10cb03-509d-567a-94dd-dfeabf356dfa",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3346,8 +3427,8 @@
               "name": "if(is_nil_or_empty(question.error), assessment_data.generic_error, question.error)",
               "config": {},
               "test": "",
-              "uuid": "06ab1ec6-5696-44ac-a4c9-bbd2bac60add",
-              "destination_block": "978e5845-cc7d-57ec-8da3-731bf34c8857",
+              "uuid": "10cecb53-839c-4352-8051-24e08e102653",
+              "destination_block": "fc0bad8c-f6a1-542d-9516-e9e0f1bf573f",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3362,7 +3443,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 270
+                        "line": 276
                       },
                       "name": "QuestionError",
                       "uuid": "d271ffe7-5cc6-591e-ae80-4b1b649defd9"
@@ -3371,7 +3452,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 272
+                        "line": 278
                       },
                       "type": "expression"
                     },
@@ -3387,10 +3468,10 @@
           "name": "question_error_case_condition_4_log",
           "type": "Core.Log",
           "config": {
-            "message": "024494ba-5049-4585-bb8b-bb923bec78e9"
+            "message": "b296083b-1595-44d2-8efa-997dfb42a4bd"
           },
           "tags": [],
-          "uuid": "978e5845-cc7d-57ec-8da3-731bf34c8857",
+          "uuid": "fc0bad8c-f6a1-542d-9516-e9e0f1bf573f",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3403,8 +3484,8 @@
               "name": "question_error_case_condition_4_log",
               "config": {},
               "test": "",
-              "uuid": "29e2b64f-2964-48e1-b361-ddc2bdc16ac4",
-              "destination_block": "ac098d06-edeb-528c-b169-b956f9f728cc",
+              "uuid": "c96afea1-a40c-477e-8888-924122b1b00b",
+              "destination_block": "a46bdc19-9b34-5aca-bd3f-d0a0ce60e7ad",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3419,7 +3500,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 270
+                        "line": 276
                       },
                       "name": "QuestionError",
                       "uuid": "d271ffe7-5cc6-591e-ae80-4b1b649defd9"
@@ -3428,7 +3509,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 273
+                        "line": 279
                       },
                       "type": "log"
                     },
@@ -3444,10 +3525,10 @@
           "name": "question_error_case_condition_4_log",
           "type": "Core.Log",
           "config": {
-            "message": "65628f77-38d7-4152-9be3-4077ab299834"
+            "message": "7d3a7415-f4c8-4879-8914-c690a58bb51c"
           },
           "tags": [],
-          "uuid": "ac098d06-edeb-528c-b169-b956f9f728cc",
+          "uuid": "a46bdc19-9b34-5aca-bd3f-d0a0ce60e7ad",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3460,8 +3541,8 @@
               "name": "question_error_case_condition_4_log",
               "config": {},
               "test": "",
-              "uuid": "4415b790-e308-45a7-8096-a24d644b9e84",
-              "destination_block": "cb51f103-e55b-544e-b909-ae8cb68fbcba",
+              "uuid": "05289bdd-554a-4f55-8873-f595af8239ff",
+              "destination_block": "93eaa52e-d6b3-5b6a-af97-a98037baa479",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3476,7 +3557,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 270
+                        "line": 276
                       },
                       "name": "QuestionError",
                       "uuid": "d271ffe7-5cc6-591e-ae80-4b1b649defd9"
@@ -3485,7 +3566,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 274
+                        "line": 280
                       },
                       "type": "log"
                     },
@@ -3501,10 +3582,10 @@
           "name": "question_error_case_condition_4_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "6df41d8a-1e2e-4300-925d-138bd39a6a0b"
+            "prompt": "0e508b36-f380-43ba-90ae-6ecea5246096"
           },
           "tags": [],
-          "uuid": "cb51f103-e55b-544e-b909-ae8cb68fbcba",
+          "uuid": "93eaa52e-d6b3-5b6a-af97-a98037baa479",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3517,7 +3598,7 @@
               "name": "Default exit to \"GetQuestion\"",
               "config": {},
               "test": "",
-              "uuid": "683b0f0a-e538-455a-bfdb-49746b7a013c",
+              "uuid": "cc169608-ad2b-496e-89c1-7022d46540f4",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -3533,7 +3614,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 270
+                        "line": 276
                       },
                       "name": "QuestionError",
                       "uuid": "d271ffe7-5cc6-591e-ae80-4b1b649defd9"
@@ -3541,7 +3622,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 275
+                        "line": 281
                       },
                       "text": {},
                       "type": "text"
@@ -3559,7 +3640,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "21d6abe3-faf0-53c3-9de9-325d26b22872",
+          "uuid": "8e2ff029-ec98-5279-ace3-02332a6b0c98",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3572,8 +3653,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_question_num\")",
               "config": {},
               "test": "",
-              "uuid": "c6101614-d39a-4528-8049-fcfa0c753327",
-              "destination_block": "f857e719-f2a2-55a9-9fd4-0be077d88ff5",
+              "uuid": "29e8dddc-0d74-48db-8e92-1b7fe67460a5",
+              "destination_block": "6c6fde26-2696-5791-9266-80b74eada484",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3588,7 +3669,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3597,7 +3678,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 257
+                        "line": 263
                       },
                       "type": "expression"
                     },
@@ -3616,7 +3697,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "f857e719-f2a2-55a9-9fd4-0be077d88ff5",
+          "uuid": "6c6fde26-2696-5791-9266-80b74eada484",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3629,8 +3710,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "4fb4c4cc-fcdd-446e-9926-dbb4bf6c94b9",
-              "destination_block": "a73b40fb-0587-5e9e-81b9-a93a78cba8ee",
+              "uuid": "48f8f45d-0635-4b77-82eb-0e2a182c8303",
+              "destination_block": "2cecf339-10a9-5e7c-908a-0093e4d4a80f",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3645,7 +3726,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3653,7 +3734,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 258
+                        "line": 264
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -3671,7 +3752,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a73b40fb-0587-5e9e-81b9-a93a78cba8ee",
+          "uuid": "2cecf339-10a9-5e7c-908a-0093e4d4a80f",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3684,8 +3765,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "f1db37f3-ad2c-427e-a65d-ff2dc2e5f80d",
-              "destination_block": "e0494db4-4c91-55ae-b3d0-a35a581f7601",
+              "uuid": "a217fc46-ee6d-44ef-b735-2a0b12f75df7",
+              "destination_block": "4ab9d975-1638-59e5-b852-2e19be2e0af2",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3700,7 +3781,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3709,7 +3790,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 259
+                        "line": 265
                       },
                       "type": "expression"
                     },
@@ -3726,7 +3807,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "e0494db4-4c91-55ae-b3d0-a35a581f7601",
+          "uuid": "4ab9d975-1638-59e5-b852-2e19be2e0af2",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3739,8 +3820,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
               "config": {},
               "test": "",
-              "uuid": "5deb0381-f856-4483-9bb0-0b67293df9e1",
-              "destination_block": "e0b8d749-9c43-594c-a3aa-cc811f16dd2c",
+              "uuid": "5763c342-8fd7-4a61-89ec-8f0f4f900b92",
+              "destination_block": "844dfb05-89cc-5a5c-9152-09bc0bfaeada",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3755,7 +3836,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3764,7 +3845,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 260
+                        "line": 266
                       },
                       "type": "expression"
                     },
@@ -3783,7 +3864,7 @@
             "value": "\"skip\""
           },
           "tags": [],
-          "uuid": "e0b8d749-9c43-594c-a3aa-cc811f16dd2c",
+          "uuid": "844dfb05-89cc-5a5c-9152-09bc0bfaeada",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3796,8 +3877,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "28cd782d-ece8-4a6f-b477-bb6054b5f704",
-              "destination_block": "1e47edd2-9507-5baf-bd37-b70515ebb892",
+              "uuid": "8c2cd759-0960-4f03-ae57-51fbe8b3bc0b",
+              "destination_block": "1790d29c-9f8c-5e63-a78e-3289d04a99c6",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3812,7 +3893,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3820,7 +3901,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 261
+                        "line": 267
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -3838,7 +3919,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "1e47edd2-9507-5baf-bd37-b70515ebb892",
+          "uuid": "1790d29c-9f8c-5e63-a78e-3289d04a99c6",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3851,8 +3932,8 @@
               "name": "skip_count + 1",
               "config": {},
               "test": "",
-              "uuid": "9abdfc2e-c16e-4098-93f9-66a571a24018",
-              "destination_block": "b44b38fa-8f20-5988-8353-6ee7b9cd5ff1",
+              "uuid": "44f1f318-9fdb-42c2-9ea8-b62e4ce6c71a",
+              "destination_block": "b59534c0-853c-5980-9a14-9673de0e5364",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3867,7 +3948,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3876,7 +3957,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 262
+                        "line": 268
                       },
                       "type": "expression"
                     },
@@ -3892,10 +3973,10 @@
           "name": "question_error_case_condition_3_log",
           "type": "Core.Log",
           "config": {
-            "message": "5698e24a-4b82-4f19-86a5-3e71935721a6"
+            "message": "ec00cbb6-8a9b-4b3f-bb31-9279372af647"
           },
           "tags": [],
-          "uuid": "b44b38fa-8f20-5988-8353-6ee7b9cd5ff1",
+          "uuid": "b59534c0-853c-5980-9a14-9673de0e5364",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3908,8 +3989,8 @@
               "name": "question_error_case_condition_3_log",
               "config": {},
               "test": "",
-              "uuid": "da107525-f0f1-4bc3-94b0-b80662d7319d",
-              "destination_block": "f7fba8e8-f8cf-5a35-9d2f-f4dac1a76ad7",
+              "uuid": "21e10900-abd2-40f4-8ac2-b3945e08d712",
+              "destination_block": "f6b124d6-0145-5a28-a9c0-a41b5b723525",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3924,7 +4005,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3933,7 +4014,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 264
+                        "line": 270
                       },
                       "type": "log"
                     },
@@ -3949,10 +4030,10 @@
           "name": "question_error_case_condition_3_log",
           "type": "Core.Log",
           "config": {
-            "message": "0dcfa15b-fe6d-4a4d-8f48-9b5bce5b5ad1"
+            "message": "2cb93c4b-1ffd-476b-8826-f39001123109"
           },
           "tags": [],
-          "uuid": "f7fba8e8-f8cf-5a35-9d2f-f4dac1a76ad7",
+          "uuid": "f6b124d6-0145-5a28-a9c0-a41b5b723525",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -3965,8 +4046,8 @@
               "name": "question_error_case_condition_3_log",
               "config": {},
               "test": "",
-              "uuid": "930e0b05-9adc-4096-8386-0eaee44ef2e4",
-              "destination_block": "b3885a0b-56ae-5bd4-92e1-ddf95c361e19",
+              "uuid": "fea5e31c-107c-4b40-93aa-3bb6ba2ea5b7",
+              "destination_block": "3fac64f0-626c-5c41-a11f-09038be3e311",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -3981,7 +4062,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -3990,7 +4071,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 265
+                        "line": 271
                       },
                       "type": "log"
                     },
@@ -4007,7 +4088,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "b3885a0b-56ae-5bd4-92e1-ddf95c361e19",
+          "uuid": "3fac64f0-626c-5c41-a11f-09038be3e311",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4020,7 +4101,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "6d0aa7f6-5d6f-4117-98bc-be654cc0276b",
+              "uuid": "1743c3e7-643a-42f6-84d8-c7dcf808f04a",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -4036,7 +4117,7 @@
                       "condition": "@question_response == lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 251
+                        "line": 257
                       },
                       "name": "QuestionError",
                       "uuid": "92a48f0f-fdce-53e5-9ac9-d872cf8ebca4"
@@ -4045,7 +4126,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 267
+                        "line": 273
                       },
                       "type": "expression"
                     },
@@ -4062,7 +4143,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "ff6aa469-3707-53fe-bf4a-2512c7753e5d",
+          "uuid": "6414e6fc-3de8-51c0-b68b-e4e0a52fb208",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4075,8 +4156,8 @@
               "name": "if(is_nil_or_empty(question.explainer), \"*Explainer:* There's no explainer for this.\", concatenate(\"*Explainer:*\", \" \", question.explainer))",
               "config": {},
               "test": "",
-              "uuid": "44f17033-7a7e-464b-aa15-16bd03f98554",
-              "destination_block": "ed3d9054-6073-5fbe-8ef2-459a231c37a7",
+              "uuid": "cbc6b001-e741-4f92-b13d-168b418c1071",
+              "destination_block": "8407db72-7cb0-5c06-8c8e-f190eaeccb29",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4091,7 +4172,7 @@
                       "condition": "has_all_members(keywords, [@question_response])",
                       "meta": {
                         "column": 1,
-                        "line": 240
+                        "line": 246
                       },
                       "name": "QuestionError",
                       "uuid": "fb54b681-3384-5511-b880-a5ec88103c42"
@@ -4100,7 +4181,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 241
+                        "line": 247
                       },
                       "type": "expression"
                     },
@@ -4116,10 +4197,10 @@
           "name": "question_error_case_condition_2_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "0d8b4688-a3a8-41ce-b869-b07da0db04a1"
+            "prompt": "26ee15f9-cb25-474e-84cf-94747048e081"
           },
           "tags": [],
-          "uuid": "ed3d9054-6073-5fbe-8ef2-459a231c37a7",
+          "uuid": "8407db72-7cb0-5c06-8c8e-f190eaeccb29",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4132,7 +4213,7 @@
               "name": "Default exit to \"GetQuestion\"",
               "config": {},
               "test": "",
-              "uuid": "6088e36b-cdb0-4279-b4f6-fda3a9dc5ff1",
+              "uuid": "5969e9d0-8d65-4b3f-913d-c1259d4e7413",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -4148,7 +4229,7 @@
                       "condition": "has_all_members(keywords, [@question_response])",
                       "meta": {
                         "column": 1,
-                        "line": 240
+                        "line": 246
                       },
                       "name": "QuestionError",
                       "uuid": "fb54b681-3384-5511-b880-a5ec88103c42"
@@ -4156,7 +4237,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 248
+                        "line": 254
                       },
                       "text": {},
                       "type": "text"
@@ -4173,10 +4254,10 @@
           "name": "question_error_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "9f9e5d7f-cfcd-4f94-bc65-38251c99f1ad"
+            "message": "8e3570f5-3629-4362-b9c8-0dc34c31c620"
           },
           "tags": [],
-          "uuid": "1b8806f5-f420-512e-91f7-3d3c54acb546",
+          "uuid": "7832657d-8591-5c25-ba77-cf77d46f1f45",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4189,8 +4270,8 @@
               "name": "question_error_case_condition_1_log",
               "config": {},
               "test": "",
-              "uuid": "f6bebbff-c262-44b0-8c79-293dc790bf3d",
-              "destination_block": "739ae588-bf36-5219-8cc6-0f4c4251d536",
+              "uuid": "9615703c-3d2b-460e-8bec-7ab8930b1008",
+              "destination_block": "974cce10-1b86-52d2-9856-af1ddad494bc",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4205,7 +4286,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 221
+                        "line": 227
                       },
                       "name": "QuestionError",
                       "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
@@ -4214,7 +4295,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 225
+                        "line": 231
                       },
                       "type": "log"
                     },
@@ -4231,7 +4312,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "739ae588-bf36-5219-8cc6-0f4c4251d536",
+          "uuid": "974cce10-1b86-52d2-9856-af1ddad494bc",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4244,8 +4325,8 @@
               "name": "if(is_nil_or_empty(question.error), assessment_data.generic_error, question.error)",
               "config": {},
               "test": "",
-              "uuid": "124b8cfa-be4a-4769-b592-aa2151ef4aa8",
-              "destination_block": "23bf1ff8-bff8-5180-999d-3554a0863ff8",
+              "uuid": "613b7e72-098f-462b-a6e0-fb28cf4b3951",
+              "destination_block": "0726cc20-0452-5c44-a370-a7b613e30b7a",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4260,339 +4341,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 221
-                      },
-                      "name": "QuestionError",
-                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 230
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "type",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "23bf1ff8-bff8-5180-999d-3554a0863ff8",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "questions[question_num].question_type",
-              "config": {},
-              "test": "",
-              "uuid": "e3717b86-f5ae-4949-9629-b84013a4eb63",
-              "destination_block": "15beca8a-5314-59eb-a8c6-b75a90c595ba",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 221
-                      },
-                      "name": "QuestionError",
-                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 231
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "lower_bound_year",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "15beca8a-5314-59eb-a8c6-b75a90c595ba",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "get_year - range",
-              "config": {},
-              "test": "",
-              "uuid": "e011ac2f-c015-45ef-af0a-e0d9acf89347",
-              "destination_block": "1755c2b1-487e-5e67-b8d5-35da6ef6551a",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 221
-                      },
-                      "name": "QuestionError",
-                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 232
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "question_error_case_condition_1_log",
-          "type": "Core.Log",
-          "config": {
-            "message": "9b643a11-a67d-4dcb-bb19-c3417c06f124"
-          },
-          "tags": [],
-          "uuid": "1755c2b1-487e-5e67-b8d5-35da6ef6551a",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "question_error_case_condition_1_log",
-              "config": {},
-              "test": "",
-              "uuid": "07acaab7-3dea-4d29-84ea-f5c6fb94c84a",
-              "destination_block": "ad5b1e16-bd05-5fed-9139-eb459e5b73e1",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 221
-                      },
-                      "name": "QuestionError",
-                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
-                    },
-                    "card_item": {
-                      "log": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 233
-                      },
-                      "type": "log"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "replace_current_year",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "ad5b1e16-bd05-5fed-9139-eb459e5b73e1",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "substitute(\"@error\", \"{current_year}\", \"@get_year\")",
-              "config": {},
-              "test": "",
-              "uuid": "8d5c8e78-ce76-4288-adea-b626d66ad07a",
-              "destination_block": "d146f6a9-ec1b-5281-afe1-6137844dca4b",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 221
-                      },
-                      "name": "QuestionError",
-                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 234
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "substituted_text",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "d146f6a9-ec1b-5281-afe1-6137844dca4b",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "substitute(\"@replace_current_year\", \"{lower_bound}\", \"@lower_bound_year\")",
-              "config": {},
-              "test": "",
-              "uuid": "d68a951e-a46c-452c-8310-a4aa81629814",
-              "destination_block": "974cce10-1b86-52d2-9856-af1ddad494bc",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 221
-                      },
-                      "name": "QuestionError",
-                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 235
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "styled_error",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "974cce10-1b86-52d2-9856-af1ddad494bc",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "concatenate(\"*Error:*\", \" \", \"@substituted_text\")",
-              "config": {},
-              "test": "",
-              "uuid": "9fb63adb-2c23-430c-b4a3-ae4f08a3d5a1",
-              "destination_block": "3a9b5254-1345-5adc-91d0-d88f5d4ee1f9",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 221
+                        "line": 227
                       },
                       "name": "QuestionError",
                       "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
@@ -4614,13 +4363,11 @@
         },
         {
           "label": null,
-          "name": "question_error_case_condition_1_text",
-          "type": "MobilePrimitives.Message",
-          "config": {
-            "prompt": "2cb075a4-9e6f-4b9c-a92a-46389735a807"
-          },
+          "name": "type",
+          "type": "Core.Case",
+          "config": {},
           "tags": [],
-          "uuid": "3a9b5254-1345-5adc-91d0-d88f5d4ee1f9",
+          "uuid": "0726cc20-0452-5c44-a370-a7b613e30b7a",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4630,11 +4377,11 @@
           "exits": [
             {
               "default": true,
-              "name": "Default exit to \"GetQuestion\"",
+              "name": "questions[question_num].question_type",
               "config": {},
               "test": "",
-              "uuid": "9ca8ccc1-69e1-406e-a1eb-b4005153f2f4",
-              "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
+              "uuid": "391ee146-102d-430a-8cf2-ae07df4627c1",
+              "destination_block": "69001d01-ec32-52dd-b5e5-11647b6c37ac",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4649,18 +4396,18 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 221
+                        "line": 227
                       },
                       "name": "QuestionError",
                       "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
                     },
                     "card_item": {
+                      "expression": {},
                       "meta": {
                         "column": 3,
                         "line": 237
                       },
-                      "text": {},
-                      "type": "text"
+                      "type": "expression"
                     },
                     "index": 0
                   }
@@ -4671,13 +4418,11 @@
         },
         {
           "label": null,
-          "name": "question_error_case_condition_0_log",
-          "type": "Core.Log",
-          "config": {
-            "message": "4005811b-54c4-4c91-a88d-2860d2d449d0"
-          },
+          "name": "lower_bound_year",
+          "type": "Core.Case",
+          "config": {},
           "tags": [],
-          "uuid": "8942a297-cff4-507f-a1d8-c941bccc3dc6",
+          "uuid": "69001d01-ec32-52dd-b5e5-11647b6c37ac",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4687,11 +4432,11 @@
           "exits": [
             {
               "default": true,
-              "name": "question_error_case_condition_0_log",
+              "name": "get_year - range",
               "config": {},
               "test": "",
-              "uuid": "7629dd07-8227-49ba-814d-be7075b08406",
-              "destination_block": "a94ef11a-fd7c-5eab-b746-2292ebd0bc1e",
+              "uuid": "a5904947-9536-4003-bc17-f2b9c9bd7074",
+              "destination_block": "e225a9c8-dd1c-5012-91f1-f6a58e475bf1",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4703,19 +4448,76 @@
                 "stacks_dsl": {
                   "0.1.0": {
                     "card": {
-                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 204
+                        "line": 227
                       },
                       "name": "QuestionError",
-                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 238
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_error_case_condition_1_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "17e1f784-af2c-4ce3-a872-e859545a0147"
+          },
+          "tags": [],
+          "uuid": "e225a9c8-dd1c-5012-91f1-f6a58e475bf1",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question_error_case_condition_1_log",
+              "config": {},
+              "test": "",
+              "uuid": "f4f27d98-4f38-4732-b6b3-e247404513f2",
+              "destination_block": "c1023695-d255-545e-8af3-f00594b117e2",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 227
+                      },
+                      "name": "QuestionError",
+                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
                     },
                     "card_item": {
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 208
+                        "line": 239
                       },
                       "type": "log"
                     },
@@ -4728,11 +4530,11 @@
         },
         {
           "label": null,
-          "name": "error",
+          "name": "replace_current_year",
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a94ef11a-fd7c-5eab-b746-2292ebd0bc1e",
+          "uuid": "c1023695-d255-545e-8af3-f00594b117e2",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4742,11 +4544,11 @@
           "exits": [
             {
               "default": true,
-              "name": "if(is_nil_or_empty(question.error), assessment_data.generic_error, question.error)",
+              "name": "substitute(\"@error\", \"{current_year}\", \"@get_year\")",
               "config": {},
               "test": "",
-              "uuid": "5e22a535-efcb-41c2-9988-74d300a18fe3",
-              "destination_block": "a264b1df-1f2d-5b2b-b308-cc56c91049ad",
+              "uuid": "8c793ced-405f-450b-aa3c-e7cb50e12482",
+              "destination_block": "ff6aa469-3707-53fe-bf4a-2512c7753e5d",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4758,129 +4560,19 @@
                 "stacks_dsl": {
                   "0.1.0": {
                     "card": {
-                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 204
+                        "line": 227
                       },
                       "name": "QuestionError",
-                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
                     },
                     "card_item": {
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 213
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "type",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "a264b1df-1f2d-5b2b-b308-cc56c91049ad",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "questions[question_num].question_type",
-              "config": {},
-              "test": "",
-              "uuid": "e35e3da8-6a88-4599-90ef-ad766936c6d7",
-              "destination_block": "349843b7-1ef9-5c3a-8ff7-8bf6bea3b853",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 204
-                      },
-                      "name": "QuestionError",
-                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 214
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "replace_min",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "349843b7-1ef9-5c3a-8ff7-8bf6bea3b853",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "substitute(\"@error\", \"{min}\", \"@min\")",
-              "config": {},
-              "test": "",
-              "uuid": "51b2549a-0125-44f5-a3b1-5c6c5356d663",
-              "destination_block": "91d2fc30-1ee1-5128-83c2-a4f006a7437c",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
-                      "meta": {
-                        "column": 1,
-                        "line": 204
-                      },
-                      "name": "QuestionError",
-                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 215
+                        "line": 240
                       },
                       "type": "expression"
                     },
@@ -4897,7 +4589,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "91d2fc30-1ee1-5128-83c2-a4f006a7437c",
+          "uuid": "ff6aa469-3707-53fe-bf4a-2512c7753e5d",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4907,11 +4599,11 @@
           "exits": [
             {
               "default": true,
-              "name": "substitute(\"@replace_min\", \"{max}\", \"@max\")",
+              "name": "substitute(\"@replace_current_year\", \"{lower_bound}\", \"@lower_bound_year\")",
               "config": {},
               "test": "",
-              "uuid": "4a11082d-69dc-4dc1-859c-236888753500",
-              "destination_block": "b396c5ab-4ae9-525b-ba69-2ad26ab7fb06",
+              "uuid": "9584acac-0c09-4dc1-b6d1-f9816ae87c74",
+              "destination_block": "7160dc6c-802b-5c6f-acee-31ad5d862960",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4923,19 +4615,19 @@
                 "stacks_dsl": {
                   "0.1.0": {
                     "card": {
-                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 204
+                        "line": 227
                       },
                       "name": "QuestionError",
-                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
                     },
                     "card_item": {
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 216
+                        "line": 241
                       },
                       "type": "expression"
                     },
@@ -4952,7 +4644,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "b396c5ab-4ae9-525b-ba69-2ad26ab7fb06",
+          "uuid": "7160dc6c-802b-5c6f-acee-31ad5d862960",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -4965,8 +4657,122 @@
               "name": "concatenate(\"*Error:*\", \" \", \"@substituted_text\")",
               "config": {},
               "test": "",
-              "uuid": "d8157308-8d08-4072-92de-04d19effdeca",
-              "destination_block": "95220b6d-b5e3-5d49-9a16-9c663dc9153d",
+              "uuid": "a8861996-f0f5-4274-9db1-b3afc1c3dc4f",
+              "destination_block": "0c61b124-030a-525c-955c-436be7ee343d",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 227
+                      },
+                      "name": "QuestionError",
+                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 242
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_error_case_condition_1_text",
+          "type": "MobilePrimitives.Message",
+          "config": {
+            "prompt": "dae37736-b04f-4f1a-93ae-2054847f75a9"
+          },
+          "tags": [],
+          "uuid": "0c61b124-030a-525c-955c-436be7ee343d",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "Default exit to \"GetQuestion\"",
+              "config": {},
+              "test": "",
+              "uuid": "eebc98c6-9d3d-4e27-8021-c33c2c0894b7",
+              "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"year_of_birth_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 227
+                      },
+                      "name": "QuestionError",
+                      "uuid": "ac1ee183-60ec-5778-ba30-c7e911541bf0"
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 3,
+                        "line": 243
+                      },
+                      "text": {},
+                      "type": "text"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_error_case_condition_0_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "ac160bef-0e8f-40ee-afdb-2c0e3ed33efc"
+          },
+          "tags": [],
+          "uuid": "f37a2c3e-563e-5965-886c-990bd1b2026a",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question_error_case_condition_0_log",
+              "config": {},
+              "test": "",
+              "uuid": "355bff60-dfd6-4783-9104-bf5b8e469d05",
+              "destination_block": "bae234d0-1617-55b0-8038-5160eb5864ed",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -4981,7 +4787,62 @@
                       "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 204
+                        "line": 210
+                      },
+                      "name": "QuestionError",
+                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                    },
+                    "card_item": {
+                      "log": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 214
+                      },
+                      "type": "log"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "error",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "bae234d0-1617-55b0-8038-5160eb5864ed",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "if(is_nil_or_empty(question.error), assessment_data.generic_error, question.error)",
+              "config": {},
+              "test": "",
+              "uuid": "f63eb84e-554f-4285-a95d-0dd4eff5932b",
+              "destination_block": "c980a5fd-a7b0-53e8-bb23-8b9737009788",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 210
                       },
                       "name": "QuestionError",
                       "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
@@ -4990,7 +4851,227 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 217
+                        "line": 219
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "type",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "c980a5fd-a7b0-53e8-bb23-8b9737009788",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "questions[question_num].question_type",
+              "config": {},
+              "test": "",
+              "uuid": "8f16c753-79ca-4bdb-a30a-dc11deb9f84d",
+              "destination_block": "52cf7a9a-cf7a-5ade-b12f-9e4384066d81",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 210
+                      },
+                      "name": "QuestionError",
+                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 220
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "replace_min",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "52cf7a9a-cf7a-5ade-b12f-9e4384066d81",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "substitute(\"@error\", \"{min}\", \"@min\")",
+              "config": {},
+              "test": "",
+              "uuid": "bfa50891-07ac-4d4b-903b-e8ada43f5fa2",
+              "destination_block": "492c218a-6349-5252-bb75-d3915938721e",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 210
+                      },
+                      "name": "QuestionError",
+                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 221
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "substituted_text",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "492c218a-6349-5252-bb75-d3915938721e",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "substitute(\"@replace_min\", \"{max}\", \"@max\")",
+              "config": {},
+              "test": "",
+              "uuid": "8b17e0d2-0743-4622-88c1-a7d57886e2bc",
+              "destination_block": "5c7c0827-cf99-50cc-9c8e-73616c3d1c68",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 210
+                      },
+                      "name": "QuestionError",
+                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 222
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "styled_error",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "5c7c0827-cf99-50cc-9c8e-73616c3d1c68",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "concatenate(\"*Error:*\", \" \", \"@substituted_text\")",
+              "config": {},
+              "test": "",
+              "uuid": "67b2ebd3-23f5-46e9-adeb-0e2333601d02",
+              "destination_block": "4437a25c-96bf-5bfe-bbe5-eac1f57bcdc6",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
+                      "meta": {
+                        "column": 1,
+                        "line": 210
+                      },
+                      "name": "QuestionError",
+                      "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 223
                       },
                       "type": "expression"
                     },
@@ -5006,10 +5087,10 @@
           "name": "question_error_case_condition_0_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "4092f250-586d-484b-a76e-244cdb696513"
+            "prompt": "f56e0f5f-c0e3-4698-aa11-7dc7d23e2c53"
           },
           "tags": [],
-          "uuid": "95220b6d-b5e3-5d49-9a16-9c663dc9153d",
+          "uuid": "4437a25c-96bf-5bfe-bbe5-eac1f57bcdc6",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -5022,7 +5103,7 @@
               "name": "Default exit to \"GetQuestion\"",
               "config": {},
               "test": "",
-              "uuid": "663a718a-88dd-40e5-9265-903ef63820ec",
+              "uuid": "530b2f99-3e1d-40a3-8bca-1c454dd4d15b",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -5038,7 +5119,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\" and @question_response != lower(\"skip\")",
                       "meta": {
                         "column": 1,
-                        "line": 204
+                        "line": 210
                       },
                       "name": "QuestionError",
                       "uuid": "8691a3eb-668a-57bf-a075-7b30fd3ed174"
@@ -5046,7 +5127,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 218
+                        "line": 224
                       },
                       "text": {},
                       "type": "text"
@@ -5077,7 +5158,7 @@
               "name": "if(is_nil_or_empty(question.explainer), \"*Explainer:* There's no explainer for this.\", concatenate(\"*Explainer:*\", \" \", question.explainer))",
               "config": {},
               "test": "",
-              "uuid": "5e2495eb-b555-424c-b280-a8ad2e7c5958",
+              "uuid": "e20598f2-b13e-4f94-829c-2f590cadc45f",
               "destination_block": "0244520a-06a8-576d-8cf5-327ed5e60da0",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -5118,7 +5199,7 @@
           "name": "age_explainer_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "df11f381-8706-4493-b54d-baea1f4c5a23"
+            "prompt": "1136a0ac-f2db-455c-8b97-a426c72be3c3"
           },
           "tags": [],
           "uuid": "0244520a-06a8-576d-8cf5-327ed5e60da0",
@@ -5134,7 +5215,7 @@
               "name": "Default exit to \"GetQuestion\"",
               "config": {},
               "test": "",
-              "uuid": "b9041737-2d93-4f31-bdbd-4c45905ca952",
+              "uuid": "7c3c4ded-180c-44ed-9f5c-a53c108f4fdd",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -5184,7 +5265,7 @@
               "name": "Exit for validate_age_case_condition_0",
               "config": {},
               "test": "has_all_members(keywords, [question_response]) == true",
-              "uuid": "5f925337-a8b8-4179-982b-8682dfb3ad9e",
+              "uuid": "8280d32f-5c12-499c-b198-cd556d664927",
               "destination_block": "72b095af-9dbb-5b5b-b5e1-a767f55c926f",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -5194,7 +5275,7 @@
               "name": "Exit for validate_age_case_condition_1",
               "config": {},
               "test": "or(not(isnumber(question_response)), question_response > 150)",
-              "uuid": "6d5998f0-cde4-414a-8991-ac9af8a8033c",
+              "uuid": "c0bf1132-7437-4166-a600-b21cc4ac8bf2",
               "destination_block": "9cfebafe-defc-5d77-96e0-24284689a769",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -5204,7 +5285,7 @@
               "name": "Exit for validate_age_case_condition_2",
               "config": {},
               "test": null,
-              "uuid": "ff5fc0ac-2847-427e-8aa7-83ce00c59e24",
+              "uuid": "b0117609-12c4-498e-9a6e-e0ba8ad17321",
               "destination_block": "9da9f307-1c40-5e52-8f6f-136a5e380920",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -5218,7 +5299,7 @@
           "name": "validate_age_case_condition_2_log",
           "type": "Core.Log",
           "config": {
-            "message": "73e7ef0a-4e74-46da-9b18-6ca419c1dfe5"
+            "message": "d98ca178-a302-498d-b70c-9df8d33e83ba"
           },
           "tags": [],
           "uuid": "9da9f307-1c40-5e52-8f6f-136a5e380920",
@@ -5234,7 +5315,7 @@
               "name": "Default exit to \"QuestionResponse\"",
               "config": {},
               "test": "",
-              "uuid": "8fa94b1d-0678-4374-bde2-a726c20cf3df",
+              "uuid": "9a0b075b-f2dd-4356-a7f7-0772df9b7ae0",
               "destination_block": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -5275,7 +5356,7 @@
           "name": "validate_age_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "0cfa26e3-dbc5-4249-833b-c6b75889bc8c"
+            "message": "f88f59fe-38c7-467a-a7f3-cea4235031e7"
           },
           "tags": [],
           "uuid": "9cfebafe-defc-5d77-96e0-24284689a769",
@@ -5291,7 +5372,7 @@
               "name": "Default exit to \"QuestionError\"",
               "config": {},
               "test": "",
-              "uuid": "e8f87c21-7602-4698-8e58-f833ed7982a5",
+              "uuid": "9be10b55-2762-4277-8760-226ac949edbb",
               "destination_block": "8691a3eb-668a-57bf-a075-7b30fd3ed174",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -5332,7 +5413,7 @@
           "name": "validate_age_case_condition_0_log",
           "type": "Core.Log",
           "config": {
-            "message": "29c04201-8e62-444e-a081-ec356f61af2c"
+            "message": "7adac2e5-3a12-4d78-89b6-dc079e9d9158"
           },
           "tags": [],
           "uuid": "72b095af-9dbb-5b5b-b5e1-a767f55c926f",
@@ -5348,7 +5429,7 @@
               "name": "Default exit to \"AgeExplainer\"",
               "config": {},
               "test": "",
-              "uuid": "97c9ee2a-8c7f-4ac4-9c28-95f7aecedb72",
+              "uuid": "f0347c1d-3ab1-44df-a99e-1d7b19b951f9",
               "destination_block": "6e8bb9e0-51ac-5785-b57a-1f1092a6acf4",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -5398,8 +5479,8 @@
               "name": "Exit for question_response_case_condition_0",
               "config": {},
               "test": "questions[question_num].question_type == \"integer_question\"",
-              "uuid": "e8c92e04-2473-4659-8611-11c34e47a442",
-              "destination_block": "4ed68e25-266a-5c0a-84da-6ef6621c3241",
+              "uuid": "4c48b9dd-708d-40a9-b947-72d27cfcf3c2",
+              "destination_block": "f30f6263-31d8-5999-9443-96a2a8b33a80",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -5408,8 +5489,8 @@
               "name": "Exit for question_response_case_condition_1",
               "config": {},
               "test": "questions[question_num].question_type == \"freetext_question\"",
-              "uuid": "3c073984-bac3-4ae6-8ac1-bf056ec606d0",
-              "destination_block": "7fdfbbe4-3efb-58fe-b789-db871ad587c1",
+              "uuid": "f21bd5b1-5755-437a-bf12-37c165e575ba",
+              "destination_block": "6e416817-7df2-50d4-8cbc-377e18aa08ca",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -5418,8 +5499,8 @@
               "name": "Exit for question_response_case_condition_2",
               "config": {},
               "test": "questions[question_num].question_type == \"age_question\"",
-              "uuid": "d41cac02-d9d4-4789-a8d4-801c1fa61afe",
-              "destination_block": "c4109f98-a787-547d-b7a7-da83e16ebaa4",
+              "uuid": "0040f40b-b3a9-4eb6-86d1-e1ee5cfdf358",
+              "destination_block": "7015dd19-145e-5ab7-935b-a15bf8729280",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -5428,8 +5509,8 @@
               "name": "Exit for question_response_case_condition_3",
               "config": {},
               "test": "questions[question_num].question_type == \"year_of_birth_question\"",
-              "uuid": "c7d9f9ac-d7d0-441e-882f-3a3613c19d89",
-              "destination_block": "0b77942a-e0a9-5ff3-8792-9ccf9b6f09fb",
+              "uuid": "a6e92594-4a31-4252-896a-b0a962dc184a",
+              "destination_block": "1f96e9e2-63c7-5143-be23-ea5112986a87",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -5438,8 +5519,8 @@
               "name": "Exit for question_response_case_condition_4",
               "config": {},
               "test": "and(has_member(map(question.answers, &lower(&1.answer)), \"never\"), lower(\"@question_response\") == \"never\")",
-              "uuid": "f8ae724a-68f9-43e0-a42d-45eba68fad0f",
-              "destination_block": "aecf6c38-bc9c-5426-991e-7dffa0bd4084",
+              "uuid": "f2f06830-ecc1-4f67-99dc-9d34bdb22f08",
+              "destination_block": "5de60559-a535-5399-80de-daac346c1d1e",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -5448,8 +5529,8 @@
               "name": "Exit for question_response_case_condition_5",
               "config": {},
               "test": "lower(\"@question_response\") == \"skip\"",
-              "uuid": "bb44cf60-57d8-4291-b7c5-08358f2fb0f1",
-              "destination_block": "12ec3c45-fe69-545c-ae36-02f12e27e855",
+              "uuid": "b866cb4d-3b93-4d2b-bc56-53973e08b436",
+              "destination_block": "d46edbbd-d98a-576a-ad76-3161dcf8e4c5",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -5458,8 +5539,8 @@
               "name": "Exit for question_response_case_condition_6",
               "config": {},
               "test": null,
-              "uuid": "b7c68e41-7183-460e-9303-53275743b203",
-              "destination_block": "a7b003be-aa52-59fe-8681-765c7c8638e2",
+              "uuid": "6aa236e1-badd-4785-bda7-4a0be7a3b8cd",
+              "destination_block": "16dda224-5492-5303-bc0b-a1d11a8fe90a",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -5473,7 +5554,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a7b003be-aa52-59fe-8681-765c7c8638e2",
+          "uuid": "16dda224-5492-5303-bc0b-a1d11a8fe90a",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -5486,8 +5567,8 @@
               "name": "map(question.answers, & &1.score)",
               "config": {},
               "test": "",
-              "uuid": "86fb5eed-0e47-4caf-857c-4c1b9b619192",
-              "destination_block": "c69c4067-51a7-52ea-9d3d-5bddc865a0fd",
+              "uuid": "6969c56b-8cf0-4be9-8c79-7668acc7a6de",
+              "destination_block": "6f9f953b-231c-5908-8408-635d8fecd1fd",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -5502,7 +5583,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 461
+                        "line": 467
                       },
                       "name": "QuestionResponse",
                       "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
@@ -5511,7 +5592,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 462
+                        "line": 468
                       },
                       "type": "expression"
                     },
@@ -5528,7 +5609,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "c69c4067-51a7-52ea-9d3d-5bddc865a0fd",
+          "uuid": "6f9f953b-231c-5908-8408-635d8fecd1fd",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -5541,8 +5622,8 @@
               "name": "reduce(scores, scores[0], &max(&1, &2))",
               "config": {},
               "test": "",
-              "uuid": "b3f18e9d-b73c-4c81-a5e0-3cd716bb374e",
-              "destination_block": "02730c96-91d2-55c9-a388-a2e0da480ce9",
+              "uuid": "8e7a6922-bcbe-4664-b874-4c084af1116a",
+              "destination_block": "a53bdbf6-4c7b-52a9-9965-257d63ea1c8d",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -5557,284 +5638,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 463
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "answer",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "02730c96-91d2-55c9-a388-a2e0da480ce9",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "find(question.answers, &(&1.answer == question_response))",
-              "config": {},
-              "test": "",
-              "uuid": "6bf87764-9fb3-49be-b7ff-54994f2cf7aa",
-              "destination_block": "1da44ef9-a288-52f3-8e59-e92306ab39b0",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 464
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "question_id",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "1da44ef9-a288-52f3-8e59-e92306ab39b0",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "questions[question_num].semantic_id",
-              "config": {},
-              "test": "",
-              "uuid": "6776c041-75ad-4249-a0fb-8f815361d760",
-              "destination_block": "2a562375-9f6b-5154-a36d-c58dd95d29bf",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 465
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "result_tag",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "2a562375-9f6b-5154-a36d-c58dd95d29bf",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_question_num\")",
-              "config": {},
-              "test": "",
-              "uuid": "827397c7-d112-464f-ab36-521cea055797",
-              "destination_block": "f6dcdd7a-b20a-5061-ae35-f7117dd65a5b",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 466
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "@result_tag",
-          "type": "Core.Output",
-          "config": {
-            "value": "question_num"
-          },
-          "tags": [],
-          "uuid": "f6dcdd7a-b20a-5061-ae35-f7117dd65a5b",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "@result_tag",
-              "config": {},
-              "test": "",
-              "uuid": "0982865b-08e5-43b5-bcd5-267793546577",
-              "destination_block": "6f9f953b-231c-5908-8408-635d8fecd1fd",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "meta": {
-                        "column": 3,
                         "line": 467
-                      },
-                      "type": "write_result",
-                      "write_result": {}
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "result_tag",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "6f9f953b-231c-5908-8408-635d8fecd1fd",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
-              "config": {},
-              "test": "",
-              "uuid": "62a5d98b-f0fe-4842-bfd0-08826fe781a6",
-              "destination_block": "4b112071-32c0-52c5-b26e-7db7916ab468",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
                       },
                       "name": "QuestionResponse",
                       "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
@@ -5856,13 +5660,11 @@
         },
         {
           "label": null,
-          "name": "@result_tag",
-          "type": "Core.Output",
-          "config": {
-            "value": "answer.semantic_id"
-          },
+          "name": "answer",
+          "type": "Core.Case",
+          "config": {},
           "tags": [],
-          "uuid": "4b112071-32c0-52c5-b26e-7db7916ab468",
+          "uuid": "a53bdbf6-4c7b-52a9-9965-257d63ea1c8d",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -5872,11 +5674,11 @@
           "exits": [
             {
               "default": true,
-              "name": "@result_tag",
+              "name": "find(question.answers, &(&1.answer == question_response))",
               "config": {},
               "test": "",
-              "uuid": "cc1d8367-f719-43bb-ad95-2f42a3dee94d",
-              "destination_block": "d5af7ffb-97a3-556e-9f8f-b8ae17d54a8b",
+              "uuid": "c539c600-cb4b-4f0d-b4ab-f25547f24b35",
+              "destination_block": "3f7c3f03-3595-593f-8769-4365b8dfa6e9",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -5891,18 +5693,18 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 461
+                        "line": 467
                       },
                       "name": "QuestionResponse",
                       "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
                     },
                     "card_item": {
+                      "expression": {},
                       "meta": {
                         "column": 3,
                         "line": 470
                       },
-                      "type": "write_result",
-                      "write_result": {}
+                      "type": "expression"
                     },
                     "index": 0
                   }
@@ -5913,13 +5715,11 @@
         },
         {
           "label": null,
-          "name": "question_response_case_condition_6_log",
-          "type": "Core.Log",
-          "config": {
-            "message": "c991582d-aeaa-47f8-aba1-5a89bb6e0fbb"
-          },
+          "name": "question_id",
+          "type": "Core.Case",
+          "config": {},
           "tags": [],
-          "uuid": "d5af7ffb-97a3-556e-9f8f-b8ae17d54a8b",
+          "uuid": "3f7c3f03-3595-593f-8769-4365b8dfa6e9",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -5929,11 +5729,11 @@
           "exits": [
             {
               "default": true,
-              "name": "question_response_case_condition_6_log",
+              "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "3e2926a6-878a-4dfb-a348-c5064aac600f",
-              "destination_block": "463e5dbd-552d-5942-b626-5e3f097ac691",
+              "uuid": "4f0e3b5c-08d5-488c-b324-c40517d07d45",
+              "destination_block": "a762eb2d-f455-5e2d-9545-2ff1f3263050",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -5948,238 +5748,16 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 461
+                        "line": 467
                       },
                       "name": "QuestionResponse",
                       "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
                     },
                     "card_item": {
-                      "log": {},
+                      "expression": {},
                       "meta": {
                         "column": 3,
                         "line": 471
-                      },
-                      "type": "log"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "max_score",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "463e5dbd-552d-5942-b626-5e3f097ac691",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "max_score + max_question_score",
-              "config": {},
-              "test": "",
-              "uuid": "e3783282-4e87-4025-bb97-2d9ff7797048",
-              "destination_block": "b833e65c-d7e6-5fa6-83fa-70393c81fa92",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 473
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "score",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "b833e65c-d7e6-5fa6-83fa-70393c81fa92",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "score + answer.score",
-              "config": {},
-              "test": "",
-              "uuid": "d544be37-4b69-4aba-86d1-37e05e56a7fb",
-              "destination_block": "c15630c2-9aa8-50af-8c6a-184d524ff891",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 474
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "question_response_case_condition_6_log",
-          "type": "Core.Log",
-          "config": {
-            "message": "7661de26-31bc-49b5-8644-0a7799e60889"
-          },
-          "tags": [],
-          "uuid": "c15630c2-9aa8-50af-8c6a-184d524ff891",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "question_response_case_condition_6_log",
-              "config": {},
-              "test": "",
-              "uuid": "e105ab0e-9100-4347-b2ad-155166e0dbac",
-              "destination_block": "a72a5236-3f6f-542c-ae01-4e8dc201a0ed",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "log": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 475
-                      },
-                      "type": "log"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "question_num",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "a72a5236-3f6f-542c-ae01-4e8dc201a0ed",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "question_num + 1",
-              "config": {},
-              "test": "",
-              "uuid": "f8e0661f-49c6-418e-87af-d7399477307c",
-              "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 461
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 476
                       },
                       "type": "expression"
                     },
@@ -6196,7 +5774,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "12ec3c45-fe69-545c-ae36-02f12e27e855",
+          "uuid": "a762eb2d-f455-5e2d-9545-2ff1f3263050",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6209,8 +5787,511 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_question_num\")",
               "config": {},
               "test": "",
-              "uuid": "f2398715-779b-43b5-be47-adffbb223089",
-              "destination_block": "8fc2e84f-7c44-5bc0-b35d-0c627e2a0500",
+              "uuid": "0a813e84-fa83-4c13-9745-806d7b8f2165",
+              "destination_block": "f7b728f1-ebd3-5281-82e0-4ebed8b217c5",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 472
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "@result_tag",
+          "type": "Core.Output",
+          "config": {
+            "value": "question_num"
+          },
+          "tags": [],
+          "uuid": "f7b728f1-ebd3-5281-82e0-4ebed8b217c5",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "@result_tag",
+              "config": {},
+              "test": "",
+              "uuid": "f89a2b4d-d4ee-41d9-8855-ee8cad5653e8",
+              "destination_block": "6f529bee-4661-59c3-8736-0bb65adbd07a",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 3,
+                        "line": 473
+                      },
+                      "type": "write_result",
+                      "write_result": {}
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "result_tag",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "6f529bee-4661-59c3-8736-0bb65adbd07a",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
+              "config": {},
+              "test": "",
+              "uuid": "a87477d0-b5cb-4564-8fb0-67ef3e6a44b3",
+              "destination_block": "d876e14e-7a50-5b50-9d20-c40a5190df3b",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 475
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "@result_tag",
+          "type": "Core.Output",
+          "config": {
+            "value": "answer.semantic_id"
+          },
+          "tags": [],
+          "uuid": "d876e14e-7a50-5b50-9d20-c40a5190df3b",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "@result_tag",
+              "config": {},
+              "test": "",
+              "uuid": "b15a65e9-ead7-4684-ab75-a1524b5f3550",
+              "destination_block": "b1a8e460-9971-56af-b0da-284d153bcebc",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 3,
+                        "line": 476
+                      },
+                      "type": "write_result",
+                      "write_result": {}
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_response_case_condition_6_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "c7e32c67-f5de-4b30-ba72-1d2719b81f83"
+          },
+          "tags": [],
+          "uuid": "b1a8e460-9971-56af-b0da-284d153bcebc",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question_response_case_condition_6_log",
+              "config": {},
+              "test": "",
+              "uuid": "a712e4e6-964b-4f2f-8462-1fcbdc2d4f4f",
+              "destination_block": "d0f98b1d-f350-5f34-b0fe-f995fa66d69f",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "log": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 477
+                      },
+                      "type": "log"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "max_score",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "d0f98b1d-f350-5f34-b0fe-f995fa66d69f",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "max_score + max_question_score",
+              "config": {},
+              "test": "",
+              "uuid": "a2628bbb-56b7-465c-9998-c4950f3927a2",
+              "destination_block": "ae009f58-091e-5d66-8411-e38737c89e5f",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 479
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "score",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "ae009f58-091e-5d66-8411-e38737c89e5f",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "score + answer.score",
+              "config": {},
+              "test": "",
+              "uuid": "6227335f-f116-44b9-a3e7-c2848b08b87a",
+              "destination_block": "cff47a13-4b4d-5e85-94df-ecf190d45d39",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 480
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_response_case_condition_6_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "6d38a2d0-5378-462c-8e13-a42963dd9b13"
+          },
+          "tags": [],
+          "uuid": "cff47a13-4b4d-5e85-94df-ecf190d45d39",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question_response_case_condition_6_log",
+              "config": {},
+              "test": "",
+              "uuid": "44b39d89-77f0-409e-aa6b-71fc00caca7b",
+              "destination_block": "c70b05c4-2924-5ce0-b306-f234efc25ec2",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "log": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 481
+                      },
+                      "type": "log"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_num",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "c70b05c4-2924-5ce0-b306-f234efc25ec2",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question_num + 1",
+              "config": {},
+              "test": "",
+              "uuid": "8f9cd722-cc73-497b-8678-f9ee99733a3a",
+              "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 467
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "84a273e4-f078-57ef-8980-2774eb9c1a9c"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 482
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "result_tag",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "d46edbbd-d98a-576a-ad76-3161dcf8e4c5",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_question_num\")",
+              "config": {},
+              "test": "",
+              "uuid": "25f259bf-8e40-4d4c-bbca-a9f7d19d0147",
+              "destination_block": "e4bce01f-4fa0-5244-abce-83d1e76df2fd",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6225,7 +6306,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6234,7 +6315,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 447
+                        "line": 453
                       },
                       "type": "expression"
                     },
@@ -6253,7 +6334,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "8fc2e84f-7c44-5bc0-b35d-0c627e2a0500",
+          "uuid": "e4bce01f-4fa0-5244-abce-83d1e76df2fd",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6266,8 +6347,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "bbdf2294-87e4-4123-87f0-c14d886e8cc6",
-              "destination_block": "09b1d959-66c8-5556-b0bf-7d18e2121894",
+              "uuid": "c7744ee2-cd5e-4109-8def-7373d6d0b1d6",
+              "destination_block": "6db7bd13-65c1-55ae-a25b-0ac1b2b5a400",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6282,7 +6363,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6290,7 +6371,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 448
+                        "line": 454
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -6308,7 +6389,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "09b1d959-66c8-5556-b0bf-7d18e2121894",
+          "uuid": "6db7bd13-65c1-55ae-a25b-0ac1b2b5a400",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6321,8 +6402,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "552ada68-29ff-48fe-bd23-e379dbd8d517",
-              "destination_block": "25c7fcb5-29b1-512f-9558-2cadcda1abb9",
+              "uuid": "a4eda5e9-67f6-41a5-ade8-153b4f5faee9",
+              "destination_block": "b3e39b19-899b-5b97-a82e-e86ec9ee75eb",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6337,7 +6418,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6346,7 +6427,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 449
+                        "line": 455
                       },
                       "type": "expression"
                     },
@@ -6363,7 +6444,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "25c7fcb5-29b1-512f-9558-2cadcda1abb9",
+          "uuid": "b3e39b19-899b-5b97-a82e-e86ec9ee75eb",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6376,8 +6457,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_\", \"@question_id\")",
               "config": {},
               "test": "",
-              "uuid": "301ced99-a0a4-4a87-b545-424e5f5b0574",
-              "destination_block": "9e72a258-aced-50aa-8e57-c39348cb0f95",
+              "uuid": "5d3e2ffa-62b0-41b9-a422-d103bc837d0d",
+              "destination_block": "0001bce3-6834-5e1a-8473-e4636b2bfb55",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6392,7 +6473,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6401,7 +6482,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 450
+                        "line": 456
                       },
                       "type": "expression"
                     },
@@ -6420,7 +6501,7 @@
             "value": "\"skip\""
           },
           "tags": [],
-          "uuid": "9e72a258-aced-50aa-8e57-c39348cb0f95",
+          "uuid": "0001bce3-6834-5e1a-8473-e4636b2bfb55",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6433,8 +6514,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "ce497c33-612e-41dd-9f2d-0cb9758dd902",
-              "destination_block": "d46edbbd-d98a-576a-ad76-3161dcf8e4c5",
+              "uuid": "34d81752-db17-4496-82f9-3b874a9f74c6",
+              "destination_block": "7d622fc7-b2b0-5e6f-b7fc-83994e08c383",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6449,7 +6530,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6457,7 +6538,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 451
+                        "line": 457
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -6475,7 +6556,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "d46edbbd-d98a-576a-ad76-3161dcf8e4c5",
+          "uuid": "7d622fc7-b2b0-5e6f-b7fc-83994e08c383",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6488,8 +6569,8 @@
               "name": "skip_count + 1",
               "config": {},
               "test": "",
-              "uuid": "63cf0b7a-4abc-494c-8ec4-e1bd3833f0b7",
-              "destination_block": "8a4f08aa-8773-5d24-944e-e2484366a9b9",
+              "uuid": "cfbe6209-3bcd-4a1f-8caf-87942662eb86",
+              "destination_block": "77b5b86a-fb86-565f-9262-593f9694a25f",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6504,7 +6585,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6513,7 +6594,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 453
+                        "line": 459
                       },
                       "type": "expression"
                     },
@@ -6529,10 +6610,10 @@
           "name": "question_response_case_condition_5_log",
           "type": "Core.Log",
           "config": {
-            "message": "3e7b7e79-6ca1-4544-80ea-5bb6d94022f1"
+            "message": "f85b0cb7-f4f2-4771-9683-00ad826afe20"
           },
           "tags": [],
-          "uuid": "8a4f08aa-8773-5d24-944e-e2484366a9b9",
+          "uuid": "77b5b86a-fb86-565f-9262-593f9694a25f",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6545,8 +6626,8 @@
               "name": "question_response_case_condition_5_log",
               "config": {},
               "test": "",
-              "uuid": "4aeb19e9-7a52-4095-8d74-854912b6d23d",
-              "destination_block": "ce6af556-48f6-51bd-a3bc-a04997ce13a3",
+              "uuid": "97fe61cf-028a-4b42-ba9a-937d778f432e",
+              "destination_block": "8436a71f-e0fb-5397-ac93-b917abc751fc",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6561,7 +6642,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6570,7 +6651,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 455
+                        "line": 461
                       },
                       "type": "log"
                     },
@@ -6586,10 +6667,10 @@
           "name": "question_response_case_condition_5_log",
           "type": "Core.Log",
           "config": {
-            "message": "aead8a25-31de-4fd7-a431-4f1095abfad0"
+            "message": "bbf08dac-7735-4260-8b34-c1f01c56ca63"
           },
           "tags": [],
-          "uuid": "ce6af556-48f6-51bd-a3bc-a04997ce13a3",
+          "uuid": "8436a71f-e0fb-5397-ac93-b917abc751fc",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6602,8 +6683,8 @@
               "name": "question_response_case_condition_5_log",
               "config": {},
               "test": "",
-              "uuid": "a4f78254-a40e-4a47-b0e0-193739e35103",
-              "destination_block": "98a89676-94e6-581b-9d38-55cb89f62456",
+              "uuid": "75dec82e-3427-4697-b8fa-483eb89b5646",
+              "destination_block": "02730c96-91d2-55c9-a388-a2e0da480ce9",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6618,7 +6699,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6627,7 +6708,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 456
+                        "line": 462
                       },
                       "type": "log"
                     },
@@ -6644,7 +6725,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "98a89676-94e6-581b-9d38-55cb89f62456",
+          "uuid": "02730c96-91d2-55c9-a388-a2e0da480ce9",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6657,7 +6738,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "5e448f65-7216-4b88-94c2-d46c853f0eb2",
+              "uuid": "7f8e963d-d2a8-415b-90f3-d9dffd69c0f1",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -6673,7 +6754,7 @@
                       "condition": "lower(\"@question_response\") == \"skip\"",
                       "meta": {
                         "column": 1,
-                        "line": 441
+                        "line": 447
                       },
                       "name": "QuestionResponse",
                       "uuid": "05d3aa85-cee9-55bf-bacc-b6876ac2a66d"
@@ -6682,7 +6763,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 458
+                        "line": 464
                       },
                       "type": "expression"
                     },
@@ -6698,10 +6779,10 @@
           "name": "question_response_case_condition_4_log",
           "type": "Core.Log",
           "config": {
-            "message": "9b06e16c-13fd-4880-a9f0-8c2f73987fe6"
+            "message": "7ca8ede1-478d-4300-a4e3-b80a21af20c2"
           },
           "tags": [],
-          "uuid": "aecf6c38-bc9c-5426-991e-7dffa0bd4084",
+          "uuid": "5de60559-a535-5399-80de-daac346c1d1e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6714,8 +6795,8 @@
               "name": "question_response_case_condition_4_log",
               "config": {},
               "test": "",
-              "uuid": "b1a044c3-8c99-46cc-89cc-a1f8fecb7187",
-              "destination_block": "a5adf338-c93a-5ce1-811a-f7715a60ced3",
+              "uuid": "72fb410a-5c25-4083-b4cf-4e9fb037df6d",
+              "destination_block": "81b762eb-9f23-5d60-b20b-62c40a3f4fb4",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6730,7 +6811,7 @@
                       "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
                       "meta": {
                         "column": 1,
-                        "line": 426
+                        "line": 432
                       },
                       "name": "QuestionResponse",
                       "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
@@ -6739,7 +6820,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 430
+                        "line": 436
                       },
                       "type": "log"
                     },
@@ -6756,7 +6837,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a5adf338-c93a-5ce1-811a-f7715a60ced3",
+          "uuid": "81b762eb-9f23-5d60-b20b-62c40a3f4fb4",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -6769,8 +6850,8 @@
               "name": "find(question.answers, &(&1.answer == question_response))",
               "config": {},
               "test": "",
-              "uuid": "4cf47faa-96df-4236-bf2e-9ba88aee4403",
-              "destination_block": "8ec77539-fd25-53bd-8c08-6ec936d7bcf7",
+              "uuid": "53ca8a19-0d84-4976-8ac8-a115ea6bc2a7",
+              "destination_block": "09686a52-e77f-58d0-9fe0-c9ae53b93230",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -6785,288 +6866,7 @@
                       "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
                       "meta": {
                         "column": 1,
-                        "line": 426
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 431
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "@slug_@version_question_num",
-          "type": "Core.Output",
-          "config": {
-            "value": "question_num"
-          },
-          "tags": [],
-          "uuid": "8ec77539-fd25-53bd-8c08-6ec936d7bcf7",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "@slug_@version_question_num",
-              "config": {},
-              "test": "",
-              "uuid": "5bec33eb-83c8-4598-8b6b-46ffc21e002e",
-              "destination_block": "a91b02e8-599c-5f75-8824-cd5c8214b3dc",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 426
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
-                    },
-                    "card_item": {
-                      "meta": {
-                        "column": 3,
                         "line": 432
-                      },
-                      "type": "write_result",
-                      "write_result": {}
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "question_id",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "a91b02e8-599c-5f75-8824-cd5c8214b3dc",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "questions[question_num].semantic_id",
-              "config": {},
-              "test": "",
-              "uuid": "6da5ddf7-4327-4be1-9308-1c7eaf8d0588",
-              "destination_block": "b0359a92-548f-5702-9477-f0dcfde67c4e",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 426
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 433
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "@slug_@version_@question_id",
-          "type": "Core.Output",
-          "config": {
-            "value": "\"@question_response\""
-          },
-          "tags": [],
-          "uuid": "b0359a92-548f-5702-9477-f0dcfde67c4e",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "@slug_@version_@question_id",
-              "config": {},
-              "test": "",
-              "uuid": "5246d54f-27ab-4076-ab68-db24fa44198b",
-              "destination_block": "d638a226-f65a-5987-96d9-b4401735857f",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 426
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
-                    },
-                    "card_item": {
-                      "meta": {
-                        "column": 3,
-                        "line": 434
-                      },
-                      "type": "write_result",
-                      "write_result": {}
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "question_response_case_condition_4_log",
-          "type": "Core.Log",
-          "config": {
-            "message": "b92dd26b-b642-4999-8362-fc15caff8de1"
-          },
-          "tags": [],
-          "uuid": "d638a226-f65a-5987-96d9-b4401735857f",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "question_response_case_condition_4_log",
-              "config": {},
-              "test": "",
-              "uuid": "14682635-7151-4b07-bb82-cfd166de9632",
-              "destination_block": "81b762eb-9f23-5d60-b20b-62c40a3f4fb4",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 426
-                      },
-                      "name": "QuestionResponse",
-                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
-                    },
-                    "card_item": {
-                      "log": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 435
-                      },
-                      "type": "log"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "score",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "81b762eb-9f23-5d60-b20b-62c40a3f4fb4",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "score + answer.score",
-              "config": {},
-              "test": "",
-              "uuid": "dcabdb8e-bee2-4c4b-9eb6-391196a9c421",
-              "destination_block": "e7453fe5-ea7a-5672-b36f-969adf27475c",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
-                      "meta": {
-                        "column": 1,
-                        "line": 426
                       },
                       "name": "QuestionResponse",
                       "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
@@ -7088,11 +6888,292 @@
         },
         {
           "label": null,
+          "name": "@slug_@version_question_num",
+          "type": "Core.Output",
+          "config": {
+            "value": "question_num"
+          },
+          "tags": [],
+          "uuid": "09686a52-e77f-58d0-9fe0-c9ae53b93230",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "@slug_@version_question_num",
+              "config": {},
+              "test": "",
+              "uuid": "b89f454a-5145-46b6-b600-b3347df8b340",
+              "destination_block": "1e7349de-a071-5923-a788-f98894c0b677",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 432
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 3,
+                        "line": 438
+                      },
+                      "type": "write_result",
+                      "write_result": {}
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_id",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "1e7349de-a071-5923-a788-f98894c0b677",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "questions[question_num].semantic_id",
+              "config": {},
+              "test": "",
+              "uuid": "93263660-fcd0-472e-918a-a6de9a9b9555",
+              "destination_block": "ee0de78d-124a-50aa-a7cc-bea8971cb7de",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 432
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 439
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "@slug_@version_@question_id",
+          "type": "Core.Output",
+          "config": {
+            "value": "\"@question_response\""
+          },
+          "tags": [],
+          "uuid": "ee0de78d-124a-50aa-a7cc-bea8971cb7de",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "@slug_@version_@question_id",
+              "config": {},
+              "test": "",
+              "uuid": "67519b7f-9fc8-44af-8b09-634ae0507166",
+              "destination_block": "93483138-c3d6-54ac-bc17-70533afcf85e",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 432
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
+                    },
+                    "card_item": {
+                      "meta": {
+                        "column": 3,
+                        "line": 440
+                      },
+                      "type": "write_result",
+                      "write_result": {}
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "question_response_case_condition_4_log",
+          "type": "Core.Log",
+          "config": {
+            "message": "d214282a-66bc-4ad9-b7a2-9a3215626665"
+          },
+          "tags": [],
+          "uuid": "93483138-c3d6-54ac-bc17-70533afcf85e",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question_response_case_condition_4_log",
+              "config": {},
+              "test": "",
+              "uuid": "e626b19a-2c01-45e9-82bb-8fbedc05fa23",
+              "destination_block": "7051ba45-6923-50fd-9f63-1201728211af",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 432
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
+                    },
+                    "card_item": {
+                      "log": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 441
+                      },
+                      "type": "log"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "score",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "7051ba45-6923-50fd-9f63-1201728211af",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "score + answer.score",
+              "config": {},
+              "test": "",
+              "uuid": "6a41bace-dd1d-4883-8f5f-4386193a88ff",
+              "destination_block": "aa1e8abf-e6d8-533b-89d0-16719e9c4c04",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
+                      "meta": {
+                        "column": 1,
+                        "line": 432
+                      },
+                      "name": "QuestionResponse",
+                      "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 443
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
           "name": "question_num",
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "e7453fe5-ea7a-5672-b36f-969adf27475c",
+          "uuid": "aa1e8abf-e6d8-533b-89d0-16719e9c4c04",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7105,7 +7186,7 @@
               "name": "count(questions)",
               "config": {},
               "test": "",
-              "uuid": "84238598-64f0-48f9-bd73-2d5188076b42",
+              "uuid": "1b16735b-4920-47a2-bcb2-760ec3c6d547",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -7121,7 +7202,7 @@
                       "condition": "has_member(map(question.answers, &lower(&1.answer)), \"never\") and lower(\"@question_response\") == \"never\"",
                       "meta": {
                         "column": 1,
-                        "line": 426
+                        "line": 432
                       },
                       "name": "QuestionResponse",
                       "uuid": "a580df95-b8dd-57e0-9143-ae09a639c16f"
@@ -7130,7 +7211,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 438
+                        "line": 444
                       },
                       "type": "expression"
                     },
@@ -7147,7 +7228,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "0b77942a-e0a9-5ff3-8792-9ccf9b6f09fb",
+          "uuid": "1f96e9e2-63c7-5143-be23-ea5112986a87",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7160,8 +7241,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "428e353b-00d7-4271-bbba-8b13be4c9252",
-              "destination_block": "a2022852-130a-544e-b628-44d6619598b4",
+              "uuid": "320a7b2b-90ea-42af-9dd9-cb24f69f93a4",
+              "destination_block": "9338681d-c98f-59a9-a78d-1d6cbbc49ec1",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7176,7 +7257,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 415
+                        "line": 421
                       },
                       "name": "QuestionResponse",
                       "uuid": "2dcaedd3-a48d-5ca3-b184-63151b7b67c8"
@@ -7185,7 +7266,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 417
+                        "line": 423
                       },
                       "type": "expression"
                     },
@@ -7204,7 +7285,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "a2022852-130a-544e-b628-44d6619598b4",
+          "uuid": "9338681d-c98f-59a9-a78d-1d6cbbc49ec1",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7217,8 +7298,8 @@
               "name": "@slug_@version_question_num",
               "config": {},
               "test": "",
-              "uuid": "ddab95d1-58c8-425a-8ee1-2e3ec6fb9b31",
-              "destination_block": "b0316c7f-e2b7-5e1f-971a-c144ad61b649",
+              "uuid": "f69e08be-8ff2-46b2-9a94-3998f19eced8",
+              "destination_block": "62772736-b104-56dd-b265-1de4b646803c",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7233,7 +7314,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 415
+                        "line": 421
                       },
                       "name": "QuestionResponse",
                       "uuid": "2dcaedd3-a48d-5ca3-b184-63151b7b67c8"
@@ -7241,7 +7322,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 418
+                        "line": 424
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7261,7 +7342,7 @@
             "value": "question.question"
           },
           "tags": [],
-          "uuid": "b0316c7f-e2b7-5e1f-971a-c144ad61b649",
+          "uuid": "62772736-b104-56dd-b265-1de4b646803c",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7274,8 +7355,8 @@
               "name": "@slug_@version_question",
               "config": {},
               "test": "",
-              "uuid": "f0e11dc6-638d-4fad-bca8-84aca51a5d47",
-              "destination_block": "bab4763e-a08f-5c84-b62c-1421ee006bcc",
+              "uuid": "247e9bca-d01b-4b49-a1d0-bdf049f439e3",
+              "destination_block": "2b042201-d600-59ec-80c1-2895d45e1c42",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7290,7 +7371,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 415
+                        "line": 421
                       },
                       "name": "QuestionResponse",
                       "uuid": "2dcaedd3-a48d-5ca3-b184-63151b7b67c8"
@@ -7298,7 +7379,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 419
+                        "line": 425
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7318,7 +7399,7 @@
             "value": "\"@question_response\""
           },
           "tags": [],
-          "uuid": "bab4763e-a08f-5c84-b62c-1421ee006bcc",
+          "uuid": "2b042201-d600-59ec-80c1-2895d45e1c42",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7331,8 +7412,8 @@
               "name": "@slug_@version_@question_id",
               "config": {},
               "test": "",
-              "uuid": "7cbfc111-b8d8-4e4e-a458-542d6291ab1c",
-              "destination_block": "a09dc1fd-8362-5278-85ae-7f0fc2224aa7",
+              "uuid": "28fa6822-1bb1-43cb-9d99-5c3d66d3e65f",
+              "destination_block": "3416b67c-9070-5d24-b627-88333982afcd",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7347,7 +7428,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 415
+                        "line": 421
                       },
                       "name": "QuestionResponse",
                       "uuid": "2dcaedd3-a48d-5ca3-b184-63151b7b67c8"
@@ -7355,7 +7436,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 420
+                        "line": 426
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7373,7 +7454,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a09dc1fd-8362-5278-85ae-7f0fc2224aa7",
+          "uuid": "3416b67c-9070-5d24-b627-88333982afcd",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7386,7 +7467,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "fd62d4ac-f021-455b-ab80-580840e2b09a",
+              "uuid": "159dfdb8-2b26-489c-92d3-868d4fdee511",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -7402,7 +7483,7 @@
                       "condition": "questions[question_num].question_type == \"year_of_birth_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 415
+                        "line": 421
                       },
                       "name": "QuestionResponse",
                       "uuid": "2dcaedd3-a48d-5ca3-b184-63151b7b67c8"
@@ -7411,7 +7492,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 422
+                        "line": 428
                       },
                       "type": "expression"
                     },
@@ -7428,7 +7509,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "c4109f98-a787-547d-b7a7-da83e16ebaa4",
+          "uuid": "7015dd19-145e-5ab7-935b-a15bf8729280",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7441,8 +7522,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "c2b95d33-7040-4e5d-a8a2-f8f2f4da447c",
-              "destination_block": "814cba8a-90b1-5031-9a4c-2ff8b85160b7",
+              "uuid": "5cb006f7-090c-4357-81dc-fd23d5625669",
+              "destination_block": "0de7292c-8fbe-5dfe-85df-af678cfe4f41",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7457,7 +7538,7 @@
                       "condition": "questions[question_num].question_type == \"age_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 406
+                        "line": 412
                       },
                       "name": "QuestionResponse",
                       "uuid": "75a8cebf-518b-55fd-9a7d-b5e36d08c8b2"
@@ -7466,7 +7547,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 407
+                        "line": 413
                       },
                       "type": "expression"
                     },
@@ -7485,7 +7566,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "814cba8a-90b1-5031-9a4c-2ff8b85160b7",
+          "uuid": "0de7292c-8fbe-5dfe-85df-af678cfe4f41",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7498,8 +7579,8 @@
               "name": "@slug_@version_question_num",
               "config": {},
               "test": "",
-              "uuid": "2ed80bee-8414-4285-b234-8a921aa2c9c0",
-              "destination_block": "4216583a-3db8-540d-857c-c4a0e8be02ff",
+              "uuid": "10d7805c-4c6a-4fa2-b821-ab655af725d6",
+              "destination_block": "4c1b7dc7-4298-50c8-bbf2-3627d0f1b0ac",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7514,7 +7595,7 @@
                       "condition": "questions[question_num].question_type == \"age_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 406
+                        "line": 412
                       },
                       "name": "QuestionResponse",
                       "uuid": "75a8cebf-518b-55fd-9a7d-b5e36d08c8b2"
@@ -7522,7 +7603,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 408
+                        "line": 414
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7542,7 +7623,7 @@
             "value": "\"@question_response\""
           },
           "tags": [],
-          "uuid": "4216583a-3db8-540d-857c-c4a0e8be02ff",
+          "uuid": "4c1b7dc7-4298-50c8-bbf2-3627d0f1b0ac",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7555,8 +7636,8 @@
               "name": "@slug_@version_@question_id",
               "config": {},
               "test": "",
-              "uuid": "1236fe88-e5c8-43b9-bc95-9beb000ede81",
-              "destination_block": "4bb8f9f3-9720-50e5-9d5d-3c88e5243d76",
+              "uuid": "44f0075a-fde8-43e9-8db0-46621b8f334e",
+              "destination_block": "81fd6821-db38-5242-b3d0-7400450f5d3e",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7571,7 +7652,7 @@
                       "condition": "questions[question_num].question_type == \"age_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 406
+                        "line": 412
                       },
                       "name": "QuestionResponse",
                       "uuid": "75a8cebf-518b-55fd-9a7d-b5e36d08c8b2"
@@ -7579,7 +7660,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 409
+                        "line": 415
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7596,10 +7677,10 @@
           "name": "question_response_case_condition_2_log",
           "type": "Core.Log",
           "config": {
-            "message": "81b2add1-6e69-48d6-961f-1bef900b69c1"
+            "message": "930c61ec-860d-4e9d-9591-f6c9f663ab0d"
           },
           "tags": [],
-          "uuid": "4bb8f9f3-9720-50e5-9d5d-3c88e5243d76",
+          "uuid": "81fd6821-db38-5242-b3d0-7400450f5d3e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7612,8 +7693,8 @@
               "name": "question_response_case_condition_2_log",
               "config": {},
               "test": "",
-              "uuid": "e10f6798-1ad4-46e8-9876-84f73696c602",
-              "destination_block": "0e3476c6-2b82-5ede-a975-894c97ff205e",
+              "uuid": "0647e833-f4f2-479e-bc5c-2e84329089ef",
+              "destination_block": "9a795654-76a1-5477-bc8c-7d5ed4eab9d4",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7628,7 +7709,7 @@
                       "condition": "questions[question_num].question_type == \"age_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 406
+                        "line": 412
                       },
                       "name": "QuestionResponse",
                       "uuid": "75a8cebf-518b-55fd-9a7d-b5e36d08c8b2"
@@ -7637,7 +7718,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 410
+                        "line": 416
                       },
                       "type": "log"
                     },
@@ -7654,7 +7735,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "0e3476c6-2b82-5ede-a975-894c97ff205e",
+          "uuid": "9a795654-76a1-5477-bc8c-7d5ed4eab9d4",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7667,7 +7748,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "4dcea534-3641-4ab6-a7ea-c68d6a07c92d",
+              "uuid": "8c8c7031-c302-487b-97ec-e09a97e5ae73",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -7683,7 +7764,7 @@
                       "condition": "questions[question_num].question_type == \"age_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 406
+                        "line": 412
                       },
                       "name": "QuestionResponse",
                       "uuid": "75a8cebf-518b-55fd-9a7d-b5e36d08c8b2"
@@ -7692,7 +7773,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 412
+                        "line": 418
                       },
                       "type": "expression"
                     },
@@ -7709,7 +7790,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "7fdfbbe4-3efb-58fe-b789-db871ad587c1",
+          "uuid": "6e416817-7df2-50d4-8cbc-377e18aa08ca",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7722,8 +7803,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "21650071-67da-4818-82fa-57748ea6c62f",
-              "destination_block": "11922d81-ab71-56b9-a01c-395911028300",
+              "uuid": "0e167292-0a9a-4857-9fd4-0cea3c185c54",
+              "destination_block": "e10b4017-99e5-56f5-9a38-5f49ab2d2ffb",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7738,7 +7819,7 @@
                       "condition": "questions[question_num].question_type == \"freetext_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 396
+                        "line": 402
                       },
                       "name": "QuestionResponse",
                       "uuid": "36028161-43a6-52b0-a1fd-173fbc73cc2e"
@@ -7747,7 +7828,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 398
+                        "line": 404
                       },
                       "type": "expression"
                     },
@@ -7766,7 +7847,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "11922d81-ab71-56b9-a01c-395911028300",
+          "uuid": "e10b4017-99e5-56f5-9a38-5f49ab2d2ffb",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7779,8 +7860,8 @@
               "name": "@slug_@version_question_num",
               "config": {},
               "test": "",
-              "uuid": "4460eb03-5e69-46bc-bdae-dd3569996a57",
-              "destination_block": "973ea3f4-2967-5724-b7e9-a4b51d01051b",
+              "uuid": "a465ca8b-b7ec-4c9e-b60a-e9475cb98a23",
+              "destination_block": "487757bb-144b-52a5-9f1b-946bdff9f4bd",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7795,7 +7876,7 @@
                       "condition": "questions[question_num].question_type == \"freetext_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 396
+                        "line": 402
                       },
                       "name": "QuestionResponse",
                       "uuid": "36028161-43a6-52b0-a1fd-173fbc73cc2e"
@@ -7803,7 +7884,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 399
+                        "line": 405
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7823,7 +7904,7 @@
             "value": "question.question"
           },
           "tags": [],
-          "uuid": "973ea3f4-2967-5724-b7e9-a4b51d01051b",
+          "uuid": "487757bb-144b-52a5-9f1b-946bdff9f4bd",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7836,8 +7917,8 @@
               "name": "@slug_@version_question",
               "config": {},
               "test": "",
-              "uuid": "91c76512-0357-4194-b847-a75849c99e0b",
-              "destination_block": "10614cf1-3bbb-519a-8801-d8a266ea3d56",
+              "uuid": "84357cc2-a69a-4f54-8b40-b2c71b93de0a",
+              "destination_block": "688c609a-51a2-55a9-ab4d-d6dc77a69949",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7852,7 +7933,7 @@
                       "condition": "questions[question_num].question_type == \"freetext_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 396
+                        "line": 402
                       },
                       "name": "QuestionResponse",
                       "uuid": "36028161-43a6-52b0-a1fd-173fbc73cc2e"
@@ -7860,7 +7941,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 400
+                        "line": 406
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7880,7 +7961,7 @@
             "value": "\"@question_response\""
           },
           "tags": [],
-          "uuid": "10614cf1-3bbb-519a-8801-d8a266ea3d56",
+          "uuid": "688c609a-51a2-55a9-ab4d-d6dc77a69949",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7893,8 +7974,8 @@
               "name": "@slug_@version_@question_id",
               "config": {},
               "test": "",
-              "uuid": "a6e2c394-b32a-4467-9297-fde33b204f20",
-              "destination_block": "2ea19e7f-8920-5b3d-ab51-dea10c58e2cb",
+              "uuid": "f5486c29-9430-456b-914c-e9db8a8f05d9",
+              "destination_block": "3a982b62-e82b-549d-b185-e7400049ef25",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -7909,7 +7990,7 @@
                       "condition": "questions[question_num].question_type == \"freetext_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 396
+                        "line": 402
                       },
                       "name": "QuestionResponse",
                       "uuid": "36028161-43a6-52b0-a1fd-173fbc73cc2e"
@@ -7917,7 +7998,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 401
+                        "line": 407
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -7935,7 +8016,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "2ea19e7f-8920-5b3d-ab51-dea10c58e2cb",
+          "uuid": "3a982b62-e82b-549d-b185-e7400049ef25",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -7948,7 +8029,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "9fb7b250-168b-4d1d-8aa1-8d225619c3a0",
+              "uuid": "3bc60470-71c1-416b-b49d-36cb078afbe0",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -7964,7 +8045,7 @@
                       "condition": "questions[question_num].question_type == \"freetext_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 396
+                        "line": 402
                       },
                       "name": "QuestionResponse",
                       "uuid": "36028161-43a6-52b0-a1fd-173fbc73cc2e"
@@ -7973,7 +8054,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 403
+                        "line": 409
                       },
                       "type": "expression"
                     },
@@ -7990,7 +8071,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "4ed68e25-266a-5c0a-84da-6ef6621c3241",
+          "uuid": "f30f6263-31d8-5999-9443-96a2a8b33a80",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8003,8 +8084,8 @@
               "name": "questions[question_num].semantic_id",
               "config": {},
               "test": "",
-              "uuid": "68141099-1f96-44fc-bc90-cb4378b37912",
-              "destination_block": "484b3960-5f7b-5816-9746-a473e13feb7d",
+              "uuid": "c06c4871-6886-4fdd-90ed-e1d9a09bfc31",
+              "destination_block": "a99b61f1-25b6-5f61-ae90-5bc17a6ebb8e",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8019,7 +8100,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8028,7 +8109,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 386
+                        "line": 392
                       },
                       "type": "expression"
                     },
@@ -8047,7 +8128,7 @@
             "value": "question_num"
           },
           "tags": [],
-          "uuid": "484b3960-5f7b-5816-9746-a473e13feb7d",
+          "uuid": "a99b61f1-25b6-5f61-ae90-5bc17a6ebb8e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8060,8 +8141,8 @@
               "name": "@slug_@version_question_num",
               "config": {},
               "test": "",
-              "uuid": "5fe52791-a9a7-47f7-a45a-03ab925317f9",
-              "destination_block": "0368dc37-f663-593f-a869-fc39ad3eead1",
+              "uuid": "0f93cdf3-404b-4e5c-a72b-8ef16846dcf6",
+              "destination_block": "e725ecf4-511e-545d-aa58-d53302f1c63f",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8076,7 +8157,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8084,7 +8165,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 387
+                        "line": 393
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -8104,7 +8185,7 @@
             "value": "question.question"
           },
           "tags": [],
-          "uuid": "0368dc37-f663-593f-a869-fc39ad3eead1",
+          "uuid": "e725ecf4-511e-545d-aa58-d53302f1c63f",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8117,8 +8198,8 @@
               "name": "@slug_@version_question",
               "config": {},
               "test": "",
-              "uuid": "4ebfda3e-b1bb-4a44-ab4d-80a6c42d5ec0",
-              "destination_block": "91561971-51ad-51a9-bb22-cead12ef426c",
+              "uuid": "4b3cec74-f14c-4bef-ba60-4f1f39e11143",
+              "destination_block": "52b16363-38ce-57c0-8c84-2699348b9b75",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8133,7 +8214,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8141,7 +8222,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 388
+                        "line": 394
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -8161,7 +8242,7 @@
             "value": "\"@question_response\""
           },
           "tags": [],
-          "uuid": "91561971-51ad-51a9-bb22-cead12ef426c",
+          "uuid": "52b16363-38ce-57c0-8c84-2699348b9b75",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8174,8 +8255,8 @@
               "name": "@slug_@version_@question_id",
               "config": {},
               "test": "",
-              "uuid": "65a5ad57-d8dc-49be-838a-5299fc07c86f",
-              "destination_block": "c55d69b8-a73c-55b5-b25c-97a46e0e33cd",
+              "uuid": "6cb1b24d-1061-43a1-9f26-f1733951175a",
+              "destination_block": "0fc03652-2e57-56c4-839f-b8490032d0e9",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8190,7 +8271,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8198,7 +8279,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 389
+                        "line": 395
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -8218,7 +8299,7 @@
             "value": "min"
           },
           "tags": [],
-          "uuid": "c55d69b8-a73c-55b5-b25c-97a46e0e33cd",
+          "uuid": "0fc03652-2e57-56c4-839f-b8490032d0e9",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8231,8 +8312,8 @@
               "name": "@slug_@version_min",
               "config": {},
               "test": "",
-              "uuid": "f0a03222-b022-44c1-a896-892262236873",
-              "destination_block": "dec27eef-5e48-53a7-a7ba-e3303e7c9a69",
+              "uuid": "9dccef5b-f1aa-4231-9547-83e600e78e01",
+              "destination_block": "e49e30f1-320d-57f1-9eb7-23e37d17ee9b",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8247,7 +8328,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8255,7 +8336,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 390
+                        "line": 396
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -8275,7 +8356,7 @@
             "value": "max"
           },
           "tags": [],
-          "uuid": "dec27eef-5e48-53a7-a7ba-e3303e7c9a69",
+          "uuid": "e49e30f1-320d-57f1-9eb7-23e37d17ee9b",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8288,8 +8369,8 @@
               "name": "@slug_@version_max",
               "config": {},
               "test": "",
-              "uuid": "a4fad36b-1bd5-433b-9ca1-2d45341b60ef",
-              "destination_block": "a44f58c1-3ccc-5bc7-999b-5dda5295adac",
+              "uuid": "9526d8ad-5d8c-45e9-b630-718a7f24c711",
+              "destination_block": "0dc94b93-ce24-51bd-b68e-776fdc84e0dd",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8304,7 +8385,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8312,7 +8393,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 391
+                        "line": 397
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -8330,7 +8411,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a44f58c1-3ccc-5bc7-999b-5dda5295adac",
+          "uuid": "0dc94b93-ce24-51bd-b68e-776fdc84e0dd",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8343,7 +8424,7 @@
               "name": "question_num + 1",
               "config": {},
               "test": "",
-              "uuid": "f3930997-9883-4854-9df0-d868c069a89b",
+              "uuid": "3ab799b4-d9cf-480b-a1a9-e74078dbe83d",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -8359,7 +8440,7 @@
                       "condition": "questions[question_num].question_type == \"integer_question\"",
                       "meta": {
                         "column": 1,
-                        "line": 384
+                        "line": 390
                       },
                       "name": "QuestionResponse",
                       "uuid": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231"
@@ -8368,7 +8449,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 393
+                        "line": 399
                       },
                       "type": "expression"
                     },
@@ -8393,7 +8474,7 @@
               "name": "Exit for question_explainer_case_condition_0",
               "config": {},
               "test": "has_all_members(keywords, [question_response])",
-              "uuid": "b9fb9f9b-d3c3-4f7c-b645-2d4aff733af6",
+              "uuid": "8eebe2a6-2303-4959-a9a8-c179a7ed8d3a",
               "destination_block": "9de56df7-8754-50ae-856b-d624f58908c5",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -8403,7 +8484,7 @@
               "name": "Exit for question_explainer_case_condition_1",
               "config": {},
               "test": null,
-              "uuid": "1d95087e-cc80-47c9-8ea5-b4dc975b6d8b",
+              "uuid": "e196da27-bcc3-4cb2-830b-249605d3e5a4",
               "destination_block": "d07b24e3-022c-5480-8117-8ef36af66eeb",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -8431,7 +8512,7 @@
               "name": "questions[question_num].question_type",
               "config": {},
               "test": "",
-              "uuid": "5e55ad4b-8b03-47a4-8a54-c72791396852",
+              "uuid": "d5f1606f-93ef-40cf-8baa-a0c82c0f16c0",
               "destination_block": "e03c1417-e21c-5c31-bc7f-08e35556f119",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -8472,7 +8553,7 @@
           "name": "question_explainer_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "a11de73b-3930-4931-b441-03e7aa42aa59"
+            "message": "80786f6e-35c4-49eb-9848-5a5c9e3a0cb8"
           },
           "tags": [],
           "uuid": "e03c1417-e21c-5c31-bc7f-08e35556f119",
@@ -8488,7 +8569,7 @@
               "name": "question_explainer_case_condition_1_log",
               "config": {},
               "test": "",
-              "uuid": "a2348814-e250-4992-9029-f78386d8db70",
+              "uuid": "9f15d989-64d4-4fa5-94dd-b20e6ed74716",
               "destination_block": "1a2e4de3-c2ae-52cd-acf9-83c3b6769919",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -8529,7 +8610,7 @@
           "name": "question_explainer_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "5dace10e-ee8a-49b2-a149-83314ad40064"
+            "message": "90ac7e13-3177-465a-8882-3ab8bf02afd8"
           },
           "tags": [],
           "uuid": "1a2e4de3-c2ae-52cd-acf9-83c3b6769919",
@@ -8545,7 +8626,7 @@
               "name": "Default exit to \"ValidateInput\"",
               "config": {},
               "test": "",
-              "uuid": "decca480-ebfd-409e-bbf8-7abe35c8b389",
+              "uuid": "9570a577-8e0d-4e81-808e-0d2d00b7d34b",
               "destination_block": "c18fd5f1-50bb-517d-b139-f95bf0ec483d",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -8600,7 +8681,7 @@
               "name": "if(is_nil_or_empty(question.explainer), \"*Explainer:* There's no explainer for this.\", concatenate(\"*Explainer:*\", \" \", question.explainer))",
               "config": {},
               "test": "",
-              "uuid": "6e717e1d-8d91-4093-ac35-ede5703c45f1",
+              "uuid": "dc9a4edd-e481-408b-84ca-f40b3218a3fb",
               "destination_block": "8e1f8c22-e920-5f2f-8270-0375aedd4678",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -8641,7 +8722,7 @@
           "name": "question_explainer_case_condition_0_text",
           "type": "MobilePrimitives.Message",
           "config": {
-            "prompt": "bf3b76d6-fe65-4fcf-a000-afd4eb779888"
+            "prompt": "864450d2-c91e-4187-a6d0-7d83b1f16ad4"
           },
           "tags": [],
           "uuid": "8e1f8c22-e920-5f2f-8270-0375aedd4678",
@@ -8657,7 +8738,7 @@
               "name": "Default exit to \"GetQuestion\"",
               "config": {},
               "test": "",
-              "uuid": "9d6efa64-4fd7-4cec-838d-2e27c3cf1303",
+              "uuid": "6ab27871-90fa-4428-a683-a81e0670638d",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -8699,7 +8780,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "1fa9bf72-8fa3-5288-9caa-e5be1b78ec5a",
+          "uuid": "152de0b6-284f-5619-b7a4-c2af42a008b0",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8712,8 +8793,8 @@
               "name": "answer_num + 1",
               "config": {},
               "test": "",
-              "uuid": "efd2a119-31c9-4d30-8a90-c492d631c241",
-              "destination_block": "c7694323-f2ef-59c4-a83f-3c6e357eee47",
+              "uuid": "5901a63d-13ef-40ab-868e-4a60d3d074aa",
+              "destination_block": "066ffca5-6baa-5331-a1c3-75a7eb8c8b77",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8728,7 +8809,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 296
+                        "line": 302
                       },
                       "name": "DisplayMultiselectAnswer",
                       "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
@@ -8737,7 +8818,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 297
+                        "line": 303
                       },
                       "type": "expression"
                     },
@@ -8754,7 +8835,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "c7694323-f2ef-59c4-a83f-3c6e357eee47",
+          "uuid": "066ffca5-6baa-5331-a1c3-75a7eb8c8b77",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -8767,8 +8848,8 @@
               "name": "count(question.answers)",
               "config": {},
               "test": "",
-              "uuid": "30a45a03-f560-4721-9901-1ea590e700fb",
-              "destination_block": "772cdbdb-b7b7-5d4f-bd12-228ee3340af8",
+              "uuid": "0d10e3ca-203a-4adf-a894-459aa60522d9",
+              "destination_block": "36a725bb-3be6-5e06-af5c-600770cc5f40",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -8783,227 +8864,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 296
-                      },
-                      "name": "DisplayMultiselectAnswer",
-                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 298
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "multiselect_question_text",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "772cdbdb-b7b7-5d4f-bd12-228ee3340af8",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "\"@question_text\"",
-              "config": {},
-              "test": "",
-              "uuid": "4d4dacb8-a80b-4d27-95eb-79bd1543a69f",
-              "destination_block": "aa70dc97-57f8-527c-ad61-8303ee610606",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 296
-                      },
-                      "name": "DisplayMultiselectAnswer",
-                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
-                    },
-                    "card_item": {
-                      "literal": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 299
-                      },
-                      "type": "literal"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "answer",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "aa70dc97-57f8-527c-ad61-8303ee610606",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "question.answers[answer_num]",
-              "config": {},
-              "test": "",
-              "uuid": "69ed02ce-803a-40a9-9199-a67767573a54",
-              "destination_block": "29ab801c-9b2c-5754-b93a-24eba8f5d424",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 296
-                      },
-                      "name": "DisplayMultiselectAnswer",
-                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 300
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "answer_text",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "29ab801c-9b2c-5754-b93a-24eba8f5d424",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "answer.answer",
-              "config": {},
-              "test": "",
-              "uuid": "aa045c07-30cf-437e-b68a-8375ee476942",
-              "destination_block": "066ffca5-6baa-5331-a1c3-75a7eb8c8b77",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 296
-                      },
-                      "name": "DisplayMultiselectAnswer",
-                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
-                    },
-                    "card_item": {
-                      "expression": {},
-                      "meta": {
-                        "column": 3,
-                        "line": 301
-                      },
-                      "type": "expression"
-                    },
-                    "index": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "label": null,
-          "name": "multiselect_question_text",
-          "type": "Core.Case",
-          "config": {},
-          "tags": [],
-          "uuid": "066ffca5-6baa-5331-a1c3-75a7eb8c8b77",
-          "ui_metadata": {
-            "canvas_coordinates": {
-              "x": 0,
-              "y": 0
-            }
-          },
-          "exits": [
-            {
-              "default": true,
-              "name": "concatenate(multiselect_question_text, \"@unichar(10)\", \"@unichar(10)\", \"@answer_text\", \"@unichar(10)\", \"@unichar(10)\", \"@display_answer_num / @num_answers\")",
-              "config": {},
-              "test": "",
-              "uuid": "e6feb82e-3a58-4182-95ac-c6e7591595ff",
-              "destination_block": "8ae1b187-ed42-51c5-ad1e-1542f240d33f",
-              "semantic_label": "",
-              "vendor_metadata": {}
-            }
-          ],
-          "semantic_label": null,
-          "vendor_metadata": {
-            "io": {
-              "turn": {
-                "stacks_dsl": {
-                  "0.1.0": {
-                    "card": {
-                      "condition": null,
-                      "meta": {
-                        "column": 1,
-                        "line": 296
+                        "line": 302
                       },
                       "name": "DisplayMultiselectAnswer",
                       "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
@@ -9025,25 +8886,245 @@
         },
         {
           "label": null,
+          "name": "multiselect_question_text",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "36a725bb-3be6-5e06-af5c-600770cc5f40",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "\"@question_text\"",
+              "config": {},
+              "test": "",
+              "uuid": "17280e6c-03bd-4d79-9a22-ce97ae079501",
+              "destination_block": "2897e7fb-d5a6-56d0-ab02-5f23a78d328f",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 302
+                      },
+                      "name": "DisplayMultiselectAnswer",
+                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
+                    },
+                    "card_item": {
+                      "literal": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 305
+                      },
+                      "type": "literal"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "answer",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "2897e7fb-d5a6-56d0-ab02-5f23a78d328f",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "question.answers[answer_num]",
+              "config": {},
+              "test": "",
+              "uuid": "1cb47661-95cb-423a-a9ce-c7d65721d6c0",
+              "destination_block": "22f917b9-0c97-54b1-94bf-8a7511a82e61",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 302
+                      },
+                      "name": "DisplayMultiselectAnswer",
+                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 306
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "answer_text",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "22f917b9-0c97-54b1-94bf-8a7511a82e61",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "answer.answer",
+              "config": {},
+              "test": "",
+              "uuid": "02f78ef9-8a89-41ae-a05a-de2444bd0822",
+              "destination_block": "74139803-da5a-5440-b6c7-0d8454d27c54",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 302
+                      },
+                      "name": "DisplayMultiselectAnswer",
+                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 307
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
+          "name": "multiselect_question_text",
+          "type": "Core.Case",
+          "config": {},
+          "tags": [],
+          "uuid": "74139803-da5a-5440-b6c7-0d8454d27c54",
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 0,
+              "y": 0
+            }
+          },
+          "exits": [
+            {
+              "default": true,
+              "name": "concatenate(multiselect_question_text, \"@unichar(10)\", \"@unichar(10)\", \"@answer_text\", \"@unichar(10)\", \"@unichar(10)\", \"@display_answer_num / @num_answers\")",
+              "config": {},
+              "test": "",
+              "uuid": "c3d6c288-e7a4-4c21-843a-17c03b71ae2b",
+              "destination_block": "a2a05347-f74b-5d33-8485-26137d5344ce",
+              "semantic_label": "",
+              "vendor_metadata": {}
+            }
+          ],
+          "semantic_label": null,
+          "vendor_metadata": {
+            "io": {
+              "turn": {
+                "stacks_dsl": {
+                  "0.1.0": {
+                    "card": {
+                      "condition": null,
+                      "meta": {
+                        "column": 1,
+                        "line": 302
+                      },
+                      "name": "DisplayMultiselectAnswer",
+                      "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
+                    },
+                    "card_item": {
+                      "expression": {},
+                      "meta": {
+                        "column": 3,
+                        "line": 310
+                      },
+                      "type": "expression"
+                    },
+                    "index": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": null,
           "name": "question_response",
           "type": "MobilePrimitives.SelectOneResponse",
           "config": {
-            "prompt": "ae69d167-2f72-4563-9292-bcc2f730a497",
+            "prompt": "8739b2fc-5a57-438a-85c3-5e454490d45f",
             "choices": [
               {
                 "name": "multiselect_response_yes",
-                "prompt": "ab120ec0-6946-43f4-8abc-c2f2f3601670",
+                "prompt": "a8220ecc-323d-4944-b64e-e6573f8d6297",
                 "test": "block.response = \"Yes\""
               },
               {
                 "name": "multiselect_response_no",
-                "prompt": "b6a9aa32-f04c-4937-ab60-3961379e57e3",
+                "prompt": "20a07f23-ffd3-42c4-956f-40411771a9fc",
                 "test": "block.response = \"No\""
               }
             ]
           },
           "tags": [],
-          "uuid": "8ae1b187-ed42-51c5-ad1e-1542f240d33f",
+          "uuid": "a2a05347-f74b-5d33-8485-26137d5344ce",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -9056,8 +9137,8 @@
               "name": "multiselect_response_yes",
               "config": {},
               "test": "block.value = \"multiselect_response_yes\"",
-              "uuid": "8b8bb0b0-49d6-4918-b8d8-452e47bb5b2b",
-              "destination_block": "3de01a2b-e5e2-51de-9941-60540411763c",
+              "uuid": "f86dfaa5-3bde-4144-b769-cfa4d384bebb",
+              "destination_block": "bbfd8bdc-32ee-5348-9ea8-7efd4f37cba0",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -9066,8 +9147,8 @@
               "name": "multiselect_response_no",
               "config": {},
               "test": "block.value = \"multiselect_response_no\"",
-              "uuid": "43f7187d-8a83-4cc3-994b-d8dcc948d918",
-              "destination_block": "27e3a016-dc6d-5dee-be50-73ce053ac14f",
+              "uuid": "7ef184f8-57b1-4789-bdb1-d6f000d189df",
+              "destination_block": "073e9c15-ed8c-5acc-89e9-19821f6567b4",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -9076,7 +9157,7 @@
               "name": "Default exit to \"MultiselectError\"",
               "config": {},
               "test": "",
-              "uuid": "65d28b38-60f8-4480-8376-8dba15a02f77",
+              "uuid": "b28d917d-1018-4387-9196-b3ecf1b02e2c",
               "destination_block": "205afeb9-04e6-5b84-8102-bb4631a81a99",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9093,7 +9174,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 296
+                        "line": 302
                       },
                       "name": "DisplayMultiselectAnswer",
                       "uuid": "72241757-c522-576c-b0e5-591f2cfbd14d"
@@ -9102,7 +9183,7 @@
                       "button_block": {},
                       "meta": {
                         "column": 3,
-                        "line": 315
+                        "line": 321
                       },
                       "type": "button_block"
                     },
@@ -9127,7 +9208,7 @@
               "name": "Exit for display_question_case_condition_0",
               "config": {},
               "test": "questions[question_num].question_type == \"multiselect_question\"",
-              "uuid": "0fdd459e-9adb-4f9d-b513-de0220fe12f9",
+              "uuid": "ec278be5-b83c-4601-b11a-a38a39c05881",
               "destination_block": "275f103f-e416-5c6b-b9a6-c5cac58cad90",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9137,7 +9218,7 @@
               "name": "Exit for display_question_case_condition_1",
               "config": {},
               "test": "count(questions[question_num].answers) > 3",
-              "uuid": "c6fb3e84-b903-4d69-961d-a47abccda640",
+              "uuid": "fa6aaa28-01f5-4789-9f18-7e7ebfbbdb2d",
               "destination_block": "1c7d42a3-533c-55a2-84b7-7c9298b10f51",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9147,7 +9228,7 @@
               "name": "Exit for display_question_case_condition_2",
               "config": {},
               "test": "questions[question_num].question_type == \"year_of_birth_question\"",
-              "uuid": "55f0ab1f-12d2-40d6-9681-2027f9e13568",
+              "uuid": "b9318596-4c4c-4bae-b076-18b2b21aa2da",
               "destination_block": "4e978c93-3b26-5039-9553-a7d683cde046",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9157,7 +9238,7 @@
               "name": "Exit for display_question_case_condition_3",
               "config": {},
               "test": "questions[question_num].question_type == \"freetext_question\"",
-              "uuid": "67c9bca7-0f5f-407d-989d-58302c4d34eb",
+              "uuid": "8f04da35-f52e-4efc-a986-64110976b385",
               "destination_block": "415f6fce-d0ba-5690-a3b6-f058d4159026",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9167,7 +9248,7 @@
               "name": "Exit for display_question_case_condition_4",
               "config": {},
               "test": "questions[question_num].question_type == \"integer_question\"",
-              "uuid": "6146c91f-ca84-42a3-8dd9-ee100e1875d4",
+              "uuid": "c02631b2-6908-43d1-8eb3-f7cda483c041",
               "destination_block": "6e5ab5bb-4a04-5c11-a762-44ed0de8c22c",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9177,7 +9258,7 @@
               "name": "Exit for display_question_case_condition_5",
               "config": {},
               "test": "questions[question_num].question_type == \"age_question\"",
-              "uuid": "6bd759cd-7fe8-428d-b4c6-8849efb2ce58",
+              "uuid": "379cdf18-6d5a-4c3d-89e4-5dc1dbb1fa96",
               "destination_block": "ada59a3a-2cf2-5b31-8135-fee24a436336",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9187,7 +9268,7 @@
               "name": "Exit for display_question_case_condition_6",
               "config": {},
               "test": null,
-              "uuid": "fd0f2307-d48b-403d-b2ed-f505c66b93ee",
+              "uuid": "ac69864d-3870-4d5f-b385-6751722612a8",
               "destination_block": "189d350a-e30f-51a1-ae83-3210859623a0",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -9215,7 +9296,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "ed011df3-0a76-4871-87c0-dee303837296",
+              "uuid": "5fda442a-71c5-4b4c-856d-a98d44b7eb0e",
               "destination_block": "78cd59ae-c837-5425-856a-24c0eabca292",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9256,9 +9337,9 @@
           "name": "question_response",
           "type": "Io.Turn.DynamicSelectOneResponse",
           "config": {
-            "prompt": "76f51a4b-e7d7-4963-b1ee-95750f99e87e",
-            "destination_block": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231",
+            "prompt": "30a825ef-a5a7-41fc-9916-b10837333b46",
             "choices": [],
+            "destination_block": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231",
             "choice_expression": "map(question.answers, &[&1.answer, &1.answer])"
           },
           "tags": [],
@@ -9275,7 +9356,7 @@
               "name": "Default exit to \"QuestionExplainer\"",
               "config": {},
               "test": "",
-              "uuid": "d333d2f5-7bb7-4ad8-921a-1b92477d2085",
+              "uuid": "2dc16c34-b75d-4b30-a8ab-efa341b6f5fc",
               "destination_block": "802042c7-f7d3-5f2e-b639-cddfe9a63eed",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9330,7 +9411,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "0b9cda11-8f31-45f3-8b13-79eb2a497635",
+              "uuid": "d643ac09-3443-4847-bc15-d1a17e28a0c4",
               "destination_block": "f4d9282c-e1b1-5472-b648-1b2cbfeac7aa",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9371,7 +9452,7 @@
           "name": "question_response",
           "type": "MobilePrimitives.OpenResponse",
           "config": {
-            "prompt": "3636ee27-668e-4d9d-aaac-518bdc063cb9",
+            "prompt": "65c4f48f-dccf-4d29-aada-443e733b9ab5",
             "max_response_characters": null
           },
           "tags": [],
@@ -9388,7 +9469,7 @@
               "name": "Default exit to \"ValidateAge\"",
               "config": {},
               "test": "",
-              "uuid": "1040bad0-0eef-43ad-ab26-55b17253e8be",
+              "uuid": "e6766c34-6e3a-48f8-9f46-7fcd6404414f",
               "destination_block": "8dd16dbc-b714-56d2-88e2-513d738e5a27",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9443,7 +9524,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "04d512a6-53a6-46fe-9293-d7e9c93c2c9d",
+              "uuid": "3ee74832-e805-49af-8a5a-1394282629a6",
               "destination_block": "c9de662f-9f2e-5d1c-b4cb-71fdf9990879",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9484,7 +9565,7 @@
           "name": "question_response",
           "type": "MobilePrimitives.OpenResponse",
           "config": {
-            "prompt": "e3fa56b3-9050-4819-aafd-88298df76420",
+            "prompt": "c9797882-020b-4f0e-b603-be06a1fbe3b3",
             "max_response_characters": null
           },
           "tags": [],
@@ -9501,7 +9582,7 @@
               "name": "question_response",
               "config": {},
               "test": "",
-              "uuid": "eb09c7db-5633-4c75-94c1-ce77777ca579",
+              "uuid": "7565cbb7-110a-48e5-ae9b-7ed899fc7090",
               "destination_block": "9d6822e0-6ead-50ce-a858-51815c33c831",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9556,7 +9637,7 @@
               "name": "questions[question_num].min",
               "config": {},
               "test": "",
-              "uuid": "34ab18fc-13dc-491b-99d0-f8b87fff967b",
+              "uuid": "3405faf6-6265-4212-8e34-14d021693801",
               "destination_block": "078b6aca-b4d1-50be-9407-72ef6e64dfa1",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9611,7 +9692,7 @@
               "name": "questions[question_num].max",
               "config": {},
               "test": "",
-              "uuid": "51a82b96-e317-416a-95a6-c51232c9fa46",
+              "uuid": "a7fb998e-c246-4825-bc55-07f0d721a576",
               "destination_block": "2e674072-3688-56dd-8f91-c1d4a89c3e0e",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9666,7 +9747,7 @@
               "name": "and(and(has_number(\"@question_response\"), has_number_gte(\"@question_response\", \"@min\")), has_number_lte(\"@question_response\", \"@max\"))",
               "config": {},
               "test": "",
-              "uuid": "57235880-1dcd-4f73-8f06-b1c1de2a00a6",
+              "uuid": "2f790c8d-eaf7-4bcc-a668-dbb28f831261",
               "destination_block": "802042c7-f7d3-5f2e-b639-cddfe9a63eed",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9721,7 +9802,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "23bd24c4-9624-49a4-ba8a-a6badc4cf531",
+              "uuid": "bbcc6c75-2c1b-4374-8f68-bc25fd50e1b4",
               "destination_block": "1bfade46-6a08-520e-be61-c45e9d87c02e",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9762,7 +9843,7 @@
           "name": "question_response",
           "type": "MobilePrimitives.OpenResponse",
           "config": {
-            "prompt": "91959c94-400c-4d6f-bffb-623dd3c94d0f",
+            "prompt": "4ac5d744-7e56-4b27-b518-e2a0cdde6e0c",
             "max_response_characters": null
           },
           "tags": [],
@@ -9779,7 +9860,7 @@
               "name": "Default exit to \"QuestionExplainer\"",
               "config": {},
               "test": "",
-              "uuid": "05870831-9642-4eb7-9264-16ffdbefdef0",
+              "uuid": "afb1c14c-9c46-4861-9c9b-264a8c7f87f4",
               "destination_block": "802042c7-f7d3-5f2e-b639-cddfe9a63eed",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9834,7 +9915,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "e581f05e-fc66-4bc8-a48f-ba73d03627d5",
+              "uuid": "85cbcc1d-e678-4d39-9708-9ba7c5e44d32",
               "destination_block": "baea128d-7cda-5de5-a04d-e784b8bea58f",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9875,7 +9956,7 @@
           "name": "question_response",
           "type": "MobilePrimitives.OpenResponse",
           "config": {
-            "prompt": "ee008566-ae6a-421c-8874-2c579fe9d269",
+            "prompt": "4bfd8d2d-68fc-4975-9545-f523ade8e085",
             "max_response_characters": null
           },
           "tags": [],
@@ -9892,7 +9973,7 @@
               "name": "question_response",
               "config": {},
               "test": "",
-              "uuid": "b2c52749-65c6-48af-b3cd-cd0c196a1465",
+              "uuid": "addcfff3-d8fd-4c72-a9c6-070a8d95925c",
               "destination_block": "43669bff-30bd-5cc4-8676-ac8a024e9151",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -9947,7 +10028,7 @@
               "name": "get_year - question_response",
               "config": {},
               "test": "",
-              "uuid": "38e04b0f-20fc-4e90-8bb2-00f22a28b997",
+              "uuid": "c8050a20-7518-4a02-a99c-da7e9ad9e66c",
               "destination_block": "bc397978-c3c1-5755-aab3-7e61b0ca7c71",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10002,7 +10083,7 @@
               "name": "and(and(and(has_number(\"@question_response\"), has_number_lte(\"@question_response\", \"@get_year\")), has_number_lte(\"@difference\", \"@range\")), has_pattern(\"@question_response\", \"^[0-9]+$\"))",
               "config": {},
               "test": "",
-              "uuid": "f075b242-c2bb-4549-9a95-692a34990dc7",
+              "uuid": "16192928-3e2c-439e-a31a-657fe052a80a",
               "destination_block": "802042c7-f7d3-5f2e-b639-cddfe9a63eed",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10057,7 +10138,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "6876de05-5219-4b59-8df3-328fa8797a76",
+              "uuid": "1363df1e-a8f9-44b4-ad82-40ed36de59ec",
               "destination_block": "4842e51a-e6ab-5075-be6b-6876357e64d8",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10098,9 +10179,9 @@
           "name": "question_response",
           "type": "Io.Turn.DynamicSelectOneResponse",
           "config": {
-            "prompt": "4deba3fb-b162-4ce0-b58f-18fd6ad01fb9",
-            "destination_block": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231",
+            "prompt": "0bbd4820-dd6e-4cb2-86dd-ca1ba018f9b2",
             "choices": [],
+            "destination_block": "832b9b6d-96a8-5a58-b3c9-d94a5b2d0231",
             "choice_expression": "map(question.answers, &[&1.answer, &1.answer])"
           },
           "tags": [],
@@ -10117,7 +10198,7 @@
               "name": "Default exit to \"QuestionExplainer\"",
               "config": {},
               "test": "",
-              "uuid": "1ec813ca-c911-4bd1-886e-a98f7ffc646c",
+              "uuid": "62d2894c-dc05-4c93-9c6b-e4ee947f7273",
               "destination_block": "802042c7-f7d3-5f2e-b639-cddfe9a63eed",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10172,7 +10253,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "85d2149b-46cd-4914-9025-2cda27516ab6",
+              "uuid": "8c4a5d28-1d9e-4559-bfb9-4c2c5a1bd37f",
               "destination_block": "a0ae728f-6eda-53e7-8c2b-b264236879f0",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10227,7 +10308,7 @@
               "name": "\"\"",
               "config": {},
               "test": "",
-              "uuid": "81d734cf-a561-406d-9be1-07b024ba3557",
+              "uuid": "c7e1af28-5b3f-4555-842a-28eee9fea33c",
               "destination_block": "7193ccfc-0012-5e0c-a10c-ee29e3d111ac",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10282,7 +10363,7 @@
               "name": "map(question.answers, & &1.score)",
               "config": {},
               "test": "",
-              "uuid": "d28b1718-aa90-4c11-aa99-ab40dfb6359b",
+              "uuid": "dba2e90a-5a64-4abd-8f33-04d781189f1b",
               "destination_block": "09d126cd-1b7d-5a88-89bf-b828e74de3ec",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10337,7 +10418,7 @@
               "name": "reduce(scores, 0, &(&1 + &2))",
               "config": {},
               "test": "",
-              "uuid": "eb887332-fa1b-4224-9ed4-61e621a65330",
+              "uuid": "9fda24a3-4e1a-4d2d-ae85-6bb2c1e97e82",
               "destination_block": "39aad5c4-4151-57f3-b5a2-8d0c987090f1",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10392,8 +10473,8 @@
               "name": "max_score + max_question_score",
               "config": {},
               "test": "",
-              "uuid": "5b3e7307-5388-4994-a0dc-fc0c290dde1a",
-              "destination_block": "1fa9bf72-8fa3-5288-9caa-e5be1b78ec5a",
+              "uuid": "995241b8-3eb3-4d4d-974c-2196637b4a12",
+              "destination_block": "152de0b6-284f-5619-b7a4-c2af42a008b0",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -10447,7 +10528,7 @@
               "name": "questions[question_num]",
               "config": {},
               "test": "",
-              "uuid": "915ef384-0607-4b33-b944-4dbfd73cff2a",
+              "uuid": "4e3d57c6-fa7a-4052-a5ca-c0b26caae98f",
               "destination_block": "6f89661d-0a3f-5bea-849e-2aaf3475d136",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10502,7 +10583,7 @@
               "name": "question.question",
               "config": {},
               "test": "",
-              "uuid": "2b3bfc5d-201f-401c-9ff3-10828809d161",
+              "uuid": "6041e416-bc18-46c8-873d-5ac237e85a28",
               "destination_block": "a95f4b7e-cf67-5bd4-8ffa-34e3d8068c46",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10557,7 +10638,7 @@
               "name": "if(is_nil_or_empty(contact.name), \"\", contact.name)",
               "config": {},
               "test": "",
-              "uuid": "f58add21-f3d7-4bf0-89fe-07cdd5620a15",
+              "uuid": "d7db3fa3-6c29-4bbe-b1fc-924b80922b78",
               "destination_block": "b16b815c-c5e0-5c6a-86fc-c33b4fe2c79e",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10612,7 +10693,7 @@
               "name": "substitute(question_text, \"{{name}}\", \"@name\")",
               "config": {},
               "test": "",
-              "uuid": "4b84df80-8d14-4663-9272-770dc5dd2097",
+              "uuid": "7100fc3b-a79a-4d18-aedf-be170ebeee51",
               "destination_block": "9ff3bcb3-256f-5fc2-b636-454c4fa816eb",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10662,7 +10743,7 @@
               "name": "Exit for check_end_case_condition_0",
               "config": {},
               "test": "question_num == count(questions)",
-              "uuid": "69776146-b93d-4338-8a26-a85e107ca1ae",
+              "uuid": "a593f730-5137-4e2a-93fc-7e59d2195b86",
               "destination_block": "77a491ab-a8e3-58e6-ba46-a57d5f5f805a",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -10672,7 +10753,7 @@
               "name": "Exit for check_end_case_condition_1",
               "config": {},
               "test": null,
-              "uuid": "65caae30-6a1c-4054-98ef-1d123b43567e",
+              "uuid": "a0b9ea45-8bdc-44fb-b53e-5c78357b568a",
               "destination_block": "c6f4022a-be64-5b41-9f6f-7da036dd453e",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -10700,7 +10781,7 @@
               "name": "Exit for GetQuestion",
               "config": {},
               "test": "true",
-              "uuid": "3b0c1581-22a1-4896-aff1-a2cacb57f986",
+              "uuid": "a975c800-36f0-426c-b7a8-2bbc072a175e",
               "destination_block": "8ae32387-1563-5b4e-bd29-37ff2a3e5ccf",
               "semantic_label": null,
               "vendor_metadata": {}
@@ -10755,7 +10836,7 @@
               "name": "score / max(max_score, 1) * 100",
               "config": {},
               "test": "",
-              "uuid": "765fd1f6-1082-43fd-8f29-ba773d8d51cb",
+              "uuid": "6e2a4da6-5836-40f1-8723-17148dd5b5f0",
               "destination_block": "422dbc5b-e5fe-5db3-9275-420b80057854",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10810,7 +10891,7 @@
               "name": "concatenate(slug, \"_end\")",
               "config": {},
               "test": "",
-              "uuid": "0135f52f-8e75-4096-8364-c1b20f737d01",
+              "uuid": "2c6f3baa-c862-4c2b-9b18-bcf8bc91be80",
               "destination_block": "01bb5dfa-37ca-5b7a-a323-272011c7887c",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10867,7 +10948,7 @@
               "name": "Default exit to \"End\"",
               "config": {},
               "test": "",
-              "uuid": "123f7c91-398c-4eed-8b99-21314b65ead2",
+              "uuid": "948f807e-d0b1-4004-80ac-f5b242ddf88a",
               "destination_block": "32ce1416-2d08-52eb-8ba7-089d0fc5fd7f",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -10908,7 +10989,7 @@
           "name": "get_assessment_log",
           "type": "Core.Log",
           "config": {
-            "message": "bde5d46a-1fa4-4362-b0f8-c70c378ebd39"
+            "message": "71cf65a4-5840-487b-8d55-e2fb345db395"
           },
           "tags": [],
           "uuid": "41d507ee-6324-5463-a333-c0db9c5264dc",
@@ -10924,7 +11005,7 @@
               "name": "get_assessment_log",
               "config": {},
               "test": "",
-              "uuid": "d98b3ad7-b2e8-4e85-a408-01ee15ba49cb",
+              "uuid": "d19b6439-84ef-4149-b397-f9c00f6765e3",
               "destination_block": "0c88e467-44ca-5732-97d3-08dca9715682",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11002,7 +11083,7 @@
               "name": "response",
               "config": {},
               "test": "",
-              "uuid": "15988c6b-38e1-4074-9426-353ffd6abe30",
+              "uuid": "6f8ff142-c994-4911-b256-741cbd768987",
               "destination_block": "eeaef0cf-3fb3-564e-8b04-c3a525512ff4",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11057,7 +11138,7 @@
               "name": "response.body.results[0]",
               "config": {},
               "test": "",
-              "uuid": "64786c69-1071-49e3-be97-6964d87df632",
+              "uuid": "6588ff07-50d6-47a6-b529-94b401949eec",
               "destination_block": "6491d76a-9dd1-5dc4-b24e-1f151b25fd99",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11112,7 +11193,7 @@
               "name": "assessment_data[\"questions\"]",
               "config": {},
               "test": "",
-              "uuid": "ffc95b92-e070-4fde-9de3-6ce665397f5c",
+              "uuid": "455dcb3b-d93b-4a23-8a5c-7875ce9c17f9",
               "destination_block": "39a6a669-d465-5cbf-9486-a7ad9903ade3",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11167,7 +11248,7 @@
               "name": "assessment_data[\"locale\"]",
               "config": {},
               "test": "",
-              "uuid": "1faa527a-fcd6-4efb-9156-879f306d1d53",
+              "uuid": "b18e9966-2f41-4085-a7b5-0cc9664e7b27",
               "destination_block": "fa402751-ae06-5d05-8c46-b17aede57e90",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11222,7 +11303,7 @@
               "name": "assessment_data[\"slug\"]",
               "config": {},
               "test": "",
-              "uuid": "9876a56e-76c1-4730-bb5b-bf4e405fb22c",
+              "uuid": "e40f96c2-3471-4c34-9829-6c0088175189",
               "destination_block": "a6568c9d-de22-5a47-89a4-8c6ac7a05cae",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11277,7 +11358,7 @@
               "name": "assessment_data[\"version\"]",
               "config": {},
               "test": "",
-              "uuid": "0cc7d3e7-6d0a-442c-9f0e-6781b6fc46b9",
+              "uuid": "1be16a01-9ff8-4218-a592-14b247550e39",
               "destination_block": "8fd838c5-8218-55d8-b6b2-20b68a736552",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11332,7 +11413,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "77f052c6-ae68-4c9c-b2dd-7705169f9ea1",
+              "uuid": "3b42ac3a-4c83-45ff-87f2-3f17862c80ef",
               "destination_block": "60a27ceb-7865-50ca-a134-49acc835931f",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11387,7 +11468,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "ccc974ee-c187-41de-95ea-1c135b085260",
+              "uuid": "17bf0acb-39af-4ae0-9c10-898aa884a004",
               "destination_block": "e6124f69-5d07-5225-8a96-07007f27eafe",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11442,7 +11523,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "190e365a-a055-46fb-9daf-dfe1cbbcce83",
+              "uuid": "2e8547d8-101c-4a6b-8d2f-2a998830703e",
               "destination_block": "37ae5eb6-cf20-5882-974b-6ba53a158031",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11497,7 +11578,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "81406c06-379b-4869-af3a-d37262620707",
+              "uuid": "216cb586-96a8-43b7-b5d2-7b93c8152675",
               "destination_block": "1648a6fc-60a5-5598-8ada-1b784be86694",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11552,7 +11633,7 @@
               "name": "\"\"",
               "config": {},
               "test": "",
-              "uuid": "fae1c409-739f-40d2-a319-fbafb0ebda6b",
+              "uuid": "12da01de-29fd-4d51-95ac-1fda0f51aa58",
               "destination_block": "48bb0531-d96f-593c-81fb-1ad12d44742e",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11607,7 +11688,7 @@
               "name": "today()",
               "config": {},
               "test": "",
-              "uuid": "08bc03db-56d9-447e-bf3e-3e941732560d",
+              "uuid": "865242cd-cf5f-4a6b-b4c0-fc702758f241",
               "destination_block": "8c3a9347-333a-51dd-b02f-38f652dbfd6c",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11662,7 +11743,7 @@
               "name": "year(get_today)",
               "config": {},
               "test": "",
-              "uuid": "b8b753f4-ecf8-49fb-bfaa-887c4d1cd5a7",
+              "uuid": "db2fb03b-5079-491a-8253-1e2bd4533ddb",
               "destination_block": "7eb8b96a-4963-58bc-a488-e934ddc1dbca",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11717,7 +11798,7 @@
               "name": "120",
               "config": {},
               "test": "",
-              "uuid": "d20ca033-3d24-4658-8d09-6c22e9371f06",
+              "uuid": "9b5bca6f-211e-47eb-96f9-bcd199d971dd",
               "destination_block": "e4fdc9d8-8138-5798-a811-3fbacd1a5072",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11772,7 +11853,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "f6cf158b-8fb8-4f59-8438-7e39692e0b26",
+              "uuid": "dfc7d151-caaf-41f9-a5aa-102074d3338c",
               "destination_block": "3e4fbb41-33e5-5841-8dbb-817b174a1129",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11827,7 +11908,7 @@
               "name": "0",
               "config": {},
               "test": "",
-              "uuid": "bfa8f631-2f03-497d-8206-8d5ae5c5291c",
+              "uuid": "5b7c673e-1dde-4487-b476-25e0c86d32fd",
               "destination_block": "3c894579-86e8-5648-9c68-408ebc9e6ef5",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11882,7 +11963,7 @@
               "name": "assessment_data[\"skip_threshold\"]",
               "config": {},
               "test": "",
-              "uuid": "62b639b5-4ab6-4965-926a-b06e78acedb1",
+              "uuid": "ccd8ce7e-80c5-416c-8e4e-bb3f9398b7b5",
               "destination_block": "04fb10a1-e739-5c07-a855-ccf80c131b9e",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11937,7 +12018,7 @@
               "name": "[\"why\", \"wy\", \"wh\", \"explain\", \"expain\", \"eplain\"]",
               "config": {},
               "test": "",
-              "uuid": "4144dc38-8497-4fbe-a13a-71372f288ced",
+              "uuid": "57859f6f-e501-4a6f-b1da-cb05b57db5ca",
               "destination_block": "9e433261-593c-548e-87af-692ee6404dc8",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -11978,7 +12059,7 @@
           "name": "get_assessment_log",
           "type": "Core.Log",
           "config": {
-            "message": "68f26ce1-7d2c-4113-ba3e-160b31fe8b59"
+            "message": "dfb51166-82f8-4e72-bea5-b6ddfeaef799"
           },
           "tags": [],
           "uuid": "9e433261-593c-548e-87af-692ee6404dc8",
@@ -11994,7 +12075,7 @@
               "name": "get_assessment_log",
               "config": {},
               "test": "",
-              "uuid": "22d3d383-01c3-4a59-9635-df45d76af6a6",
+              "uuid": "71d0b341-b6ca-4b38-a765-3a009e2ed4aa",
               "destination_block": "0febd387-4a98-5c65-ad4b-b5a51489240b",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -12051,7 +12132,7 @@
               "name": "version",
               "config": {},
               "test": "",
-              "uuid": "2045a7a6-1898-457f-9211-6cb3a3d681bd",
+              "uuid": "cd4198df-e693-4bb3-9951-636fc5e0556c",
               "destination_block": "be94bf21-0c15-5722-85c9-e86493d32c8b",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -12106,7 +12187,7 @@
               "name": "concatenate(slug, \"_\", version, \"_start\")",
               "config": {},
               "test": "",
-              "uuid": "ef0166de-1267-406e-9167-bc1d2c123786",
+              "uuid": "6dc86751-62d6-4851-99cb-beef5165f961",
               "destination_block": "fbaf76ad-be59-5122-85b8-96a89b5ccf05",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -12163,7 +12244,7 @@
               "name": "@v_start",
               "config": {},
               "test": "",
-              "uuid": "4f981e1b-7f56-4411-9d25-23a4a46047f4",
+              "uuid": "c063c860-2a36-443d-b504-bd8c7f1aed58",
               "destination_block": "9e045a4c-ede7-5f3f-a928-bf36bd78645f",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -12220,7 +12301,7 @@
               "name": "Default exit to \"CheckEnd\"",
               "config": {},
               "test": "",
-              "uuid": "c3d55891-8eb3-4d87-9e03-f43917e0afa9",
+              "uuid": "6eefaf59-aa00-403a-a655-7d55eb5c303e",
               "destination_block": "cebd16e3-4d94-572c-bcd1-6def9e904347",
               "semantic_label": "",
               "vendor_metadata": {}
@@ -12270,8 +12351,8 @@
               "name": "Exit for end_case_condition_0",
               "config": {},
               "test": "and(skip_count < skip_threshold, score_perc >= assessment_data.high_inflection)",
-              "uuid": "c26fc2d3-cfd8-4e5f-a022-47948e0dee41",
-              "destination_block": "c70b05c4-2924-5ce0-b306-f234efc25ec2",
+              "uuid": "8d45c350-392b-474d-b16b-eaf61d68c2c5",
+              "destination_block": "ccd986f7-20b4-5560-9ec7-f8828250d0aa",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -12280,8 +12361,8 @@
               "name": "Exit for end_case_condition_1",
               "config": {},
               "test": "and(and(skip_count < skip_threshold, score_perc >= assessment_data.medium_inflection), score_perc < assessment_data.high_inflection)",
-              "uuid": "512deb72-3a75-43b4-87ff-1fd205fa5c85",
-              "destination_block": "c74960f6-0f26-543a-a991-e569a542c89e",
+              "uuid": "d7232099-19d4-4671-b516-c0e9022f7938",
+              "destination_block": "080b7638-ffe8-5126-b052-84bc5b1df897",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -12290,8 +12371,8 @@
               "name": "Exit for end_case_condition_2",
               "config": {},
               "test": "skip_count >= skip_threshold",
-              "uuid": "bc9e01e2-8457-4722-a777-6c91201d324e",
-              "destination_block": "4d52e736-7b89-538c-89c4-17e4ed5dc356",
+              "uuid": "6a8fb76b-6196-4d6c-8a16-50a5f055d9f3",
+              "destination_block": "ce727d0f-630e-5904-a55f-f374c40ade5e",
               "semantic_label": null,
               "vendor_metadata": {}
             },
@@ -12300,8 +12381,8 @@
               "name": "Exit for end_case_condition_3",
               "config": {},
               "test": null,
-              "uuid": "3d78bc8f-0e4b-4120-9fcf-0cbf242d29ab",
-              "destination_block": "27443b2b-1c76-56b1-8f66-e92006e104bc",
+              "uuid": "a2d32723-bce6-4b1d-b5d9-85baa93d251a",
+              "destination_block": "1f9cdaf5-2db7-5eeb-bcf6-434d358a46a8",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -12315,7 +12396,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "27443b2b-1c76-56b1-8f66-e92006e104bc",
+          "uuid": "1f9cdaf5-2db7-5eeb-bcf6-434d358a46a8",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12328,8 +12409,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_risk\")",
               "config": {},
               "test": "",
-              "uuid": "dbfd7ec1-10b7-46b5-9a85-1502ec7fe167",
-              "destination_block": "b99a9e1f-c4fe-5150-9529-f2c33664bed1",
+              "uuid": "f78bac19-7355-44c5-8153-11e8d61cabe7",
+              "destination_block": "853392f7-37e3-51e9-84c2-9979e8529867",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12344,7 +12425,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 511
+                        "line": 517
                       },
                       "name": "End",
                       "uuid": "135d85be-cce5-5d0c-af9e-fc591fdbaeca"
@@ -12353,7 +12434,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 512
+                        "line": 518
                       },
                       "type": "expression"
                     },
@@ -12372,7 +12453,7 @@
             "value": "\"low\""
           },
           "tags": [],
-          "uuid": "b99a9e1f-c4fe-5150-9529-f2c33664bed1",
+          "uuid": "853392f7-37e3-51e9-84c2-9979e8529867",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12385,8 +12466,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "a80424ac-364d-44ea-9054-1a99482ca10f",
-              "destination_block": "3db854b1-39ae-5cbb-833b-65f6fda833b6",
+              "uuid": "e9aff56a-f97d-42e7-a4dc-fd07683cf0e7",
+              "destination_block": "d66e76cb-1902-5a60-b1aa-fbe46d4e464a",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12401,7 +12482,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 511
+                        "line": 517
                       },
                       "name": "End",
                       "uuid": "135d85be-cce5-5d0c-af9e-fc591fdbaeca"
@@ -12409,7 +12490,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 513
+                        "line": 519
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -12426,10 +12507,10 @@
           "name": "end_case_condition_3_log",
           "type": "Core.Log",
           "config": {
-            "message": "b8785e01-bdb5-436c-adfe-0a5e64bba080"
+            "message": "785be7e3-512b-43d6-99ba-915d6ca301d7"
           },
           "tags": [],
-          "uuid": "3db854b1-39ae-5cbb-833b-65f6fda833b6",
+          "uuid": "d66e76cb-1902-5a60-b1aa-fbe46d4e464a",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12442,8 +12523,8 @@
               "name": "end_case_condition_3_log",
               "config": {},
               "test": "",
-              "uuid": "e3046f10-c43d-4c47-9a06-e66461621959",
-              "destination_block": "ce06b10f-e702-5e0b-9603-6da51786a13a",
+              "uuid": "62d9e805-c080-4526-a133-467b3b35f18b",
+              "destination_block": "4a783711-66af-51b9-8123-fbb117fa66a4",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12458,7 +12539,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 511
+                        "line": 517
                       },
                       "name": "End",
                       "uuid": "135d85be-cce5-5d0c-af9e-fc591fdbaeca"
@@ -12467,7 +12548,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 514
+                        "line": 520
                       },
                       "type": "log"
                     },
@@ -12484,7 +12565,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "ce06b10f-e702-5e0b-9603-6da51786a13a",
+          "uuid": "4a783711-66af-51b9-8123-fbb117fa66a4",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12497,8 +12578,8 @@
               "name": "assessment_data.low_result_page.id",
               "config": {},
               "test": "",
-              "uuid": "d7743a2f-36ec-49ef-9b16-6a8ca35e0e26",
-              "destination_block": "bb85960f-502e-51e4-ba9f-25295ba05ca2",
+              "uuid": "370791ba-4eb6-49b2-899f-7c31dcf5a871",
+              "destination_block": "ccac40e3-1944-5842-bc6a-5fc244263c7f",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12513,7 +12594,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 511
+                        "line": 517
                       },
                       "name": "End",
                       "uuid": "135d85be-cce5-5d0c-af9e-fc591fdbaeca"
@@ -12522,7 +12603,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 515
+                        "line": 521
                       },
                       "type": "expression"
                     },
@@ -12539,7 +12620,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "bb85960f-502e-51e4-ba9f-25295ba05ca2",
+          "uuid": "ccac40e3-1944-5842-bc6a-5fc244263c7f",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12552,8 +12633,8 @@
               "name": "Exit for DisplayEndPage",
               "config": {},
               "test": "true",
-              "uuid": "4ec8708a-e4ab-495c-9cc7-a078844e7051",
-              "destination_block": "4a783711-66af-51b9-8123-fbb117fa66a4",
+              "uuid": "ca534ba8-673f-4329-a46d-876458e61658",
+              "destination_block": "cc311bb4-1f77-5fbb-bb1b-2be1124b21c2",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -12568,7 +12649,7 @@
                       "condition": null,
                       "meta": {
                         "column": 1,
-                        "line": 511
+                        "line": 517
                       },
                       "name": "End",
                       "uuid": "135d85be-cce5-5d0c-af9e-fc591fdbaeca"
@@ -12576,7 +12657,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 517
+                        "line": 523
                       },
                       "then": {},
                       "type": "then"
@@ -12594,7 +12675,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "4d52e736-7b89-538c-89c4-17e4ed5dc356",
+          "uuid": "ce727d0f-630e-5904-a55f-f374c40ade5e",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12607,8 +12688,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_risk\")",
               "config": {},
               "test": "",
-              "uuid": "80a97ff5-7e0f-43a2-8201-46ad6a6c2513",
-              "destination_block": "dff1c523-02ae-55fa-ae26-80a562a2bb25",
+              "uuid": "7ff83f90-9b79-476b-a544-e50c4f393ad5",
+              "destination_block": "a936dc75-c844-51c4-8e12-14f191c2aab3",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12623,7 +12704,7 @@
                       "condition": "skip_count >= skip_threshold",
                       "meta": {
                         "column": 1,
-                        "line": 502
+                        "line": 508
                       },
                       "name": "End",
                       "uuid": "8af47823-4747-5abf-9246-0ea6b60fa78e"
@@ -12632,7 +12713,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 503
+                        "line": 509
                       },
                       "type": "expression"
                     },
@@ -12651,7 +12732,7 @@
             "value": "\"skip_high\""
           },
           "tags": [],
-          "uuid": "dff1c523-02ae-55fa-ae26-80a562a2bb25",
+          "uuid": "a936dc75-c844-51c4-8e12-14f191c2aab3",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12664,8 +12745,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "aaf18b6f-3cd8-4ff6-861a-e30413f6f262",
-              "destination_block": "f52a421c-b65c-5e2e-a30c-becc8ca53e42",
+              "uuid": "4abda2a2-ed53-4ed0-a052-8f59b7ddf264",
+              "destination_block": "40c80c1b-37ef-5b2b-b31c-30f98e5945b7",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12680,7 +12761,7 @@
                       "condition": "skip_count >= skip_threshold",
                       "meta": {
                         "column": 1,
-                        "line": 502
+                        "line": 508
                       },
                       "name": "End",
                       "uuid": "8af47823-4747-5abf-9246-0ea6b60fa78e"
@@ -12688,7 +12769,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 504
+                        "line": 510
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -12705,10 +12786,10 @@
           "name": "end_case_condition_2_log",
           "type": "Core.Log",
           "config": {
-            "message": "4c215ee5-0925-46c7-bbc9-78e30c74e75d"
+            "message": "ae05a509-2d92-4d7b-b67d-19667ab3f63a"
           },
           "tags": [],
-          "uuid": "f52a421c-b65c-5e2e-a30c-becc8ca53e42",
+          "uuid": "40c80c1b-37ef-5b2b-b31c-30f98e5945b7",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12721,8 +12802,8 @@
               "name": "end_case_condition_2_log",
               "config": {},
               "test": "",
-              "uuid": "d0518c87-b2a8-4e9c-a36d-6e7d3afb2181",
-              "destination_block": "b7304351-c3ad-590c-b9e2-ce181d17b800",
+              "uuid": "bc797dae-f5da-4526-b68c-57e43d7f0fcb",
+              "destination_block": "27443b2b-1c76-56b1-8f66-e92006e104bc",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12737,7 +12818,7 @@
                       "condition": "skip_count >= skip_threshold",
                       "meta": {
                         "column": 1,
-                        "line": 502
+                        "line": 508
                       },
                       "name": "End",
                       "uuid": "8af47823-4747-5abf-9246-0ea6b60fa78e"
@@ -12746,7 +12827,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 505
+                        "line": 511
                       },
                       "type": "log"
                     },
@@ -12763,7 +12844,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "b7304351-c3ad-590c-b9e2-ce181d17b800",
+          "uuid": "27443b2b-1c76-56b1-8f66-e92006e104bc",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12776,8 +12857,8 @@
               "name": "assessment_data.skip_high_result_page.id",
               "config": {},
               "test": "",
-              "uuid": "73b00d42-067d-4c0a-a5d4-53f73389d340",
-              "destination_block": "a27a883c-e62a-54ef-a953-64fa38214a73",
+              "uuid": "580a30ed-a141-497a-8eec-67081219da73",
+              "destination_block": "f69977ef-2364-579d-8d53-aaa7b0e62aa1",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12792,7 +12873,7 @@
                       "condition": "skip_count >= skip_threshold",
                       "meta": {
                         "column": 1,
-                        "line": 502
+                        "line": 508
                       },
                       "name": "End",
                       "uuid": "8af47823-4747-5abf-9246-0ea6b60fa78e"
@@ -12801,7 +12882,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 506
+                        "line": 512
                       },
                       "type": "expression"
                     },
@@ -12818,7 +12899,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "a27a883c-e62a-54ef-a953-64fa38214a73",
+          "uuid": "f69977ef-2364-579d-8d53-aaa7b0e62aa1",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12831,8 +12912,8 @@
               "name": "Exit for DisplayEndPage",
               "config": {},
               "test": "true",
-              "uuid": "0d32b09b-1418-4764-9336-4f041281ee08",
-              "destination_block": "4a783711-66af-51b9-8123-fbb117fa66a4",
+              "uuid": "02e1bf12-d9f8-4880-ba4e-d1e4e99a16bf",
+              "destination_block": "cc311bb4-1f77-5fbb-bb1b-2be1124b21c2",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -12847,7 +12928,7 @@
                       "condition": "skip_count >= skip_threshold",
                       "meta": {
                         "column": 1,
-                        "line": 502
+                        "line": 508
                       },
                       "name": "End",
                       "uuid": "8af47823-4747-5abf-9246-0ea6b60fa78e"
@@ -12855,7 +12936,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 508
+                        "line": 514
                       },
                       "then": {},
                       "type": "then"
@@ -12873,7 +12954,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "c74960f6-0f26-543a-a991-e569a542c89e",
+          "uuid": "080b7638-ffe8-5126-b052-84bc5b1df897",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12886,8 +12967,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_risk\")",
               "config": {},
               "test": "",
-              "uuid": "4a0b80fe-c529-4617-ac76-f09e73ab3040",
-              "destination_block": "196c31f2-ceba-501b-82ec-3ca7c562c4c1",
+              "uuid": "5210e714-6f6e-49f6-8d0c-02f58fc4c1f2",
+              "destination_block": "b2b18233-958f-534b-9529-b6217255378d",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12902,7 +12983,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.medium_inflection and score_perc < assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 490
+                        "line": 496
                       },
                       "name": "End",
                       "uuid": "a7d1d4b4-8704-5c4e-b2bf-6a047180c846"
@@ -12911,7 +12992,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 494
+                        "line": 500
                       },
                       "type": "expression"
                     },
@@ -12930,7 +13011,7 @@
             "value": "\"medium\""
           },
           "tags": [],
-          "uuid": "196c31f2-ceba-501b-82ec-3ca7c562c4c1",
+          "uuid": "b2b18233-958f-534b-9529-b6217255378d",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -12943,8 +13024,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "5e439f20-2b1c-4e13-85d5-c0521642110f",
-              "destination_block": "3ad49b1c-d111-5f55-b04f-691568dd4f47",
+              "uuid": "68969db7-5abd-415b-b1cc-8657048ee2bd",
+              "destination_block": "8b32b646-a266-575e-b47a-d711d91f64fa",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -12959,7 +13040,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.medium_inflection and score_perc < assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 490
+                        "line": 496
                       },
                       "name": "End",
                       "uuid": "a7d1d4b4-8704-5c4e-b2bf-6a047180c846"
@@ -12967,7 +13048,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 495
+                        "line": 501
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -12984,10 +13065,10 @@
           "name": "end_case_condition_1_log",
           "type": "Core.Log",
           "config": {
-            "message": "c07f5a97-9564-4c3f-8266-1b27193438e2"
+            "message": "51811ee7-95db-41cf-ac13-9631b09217f4"
           },
           "tags": [],
-          "uuid": "3ad49b1c-d111-5f55-b04f-691568dd4f47",
+          "uuid": "8b32b646-a266-575e-b47a-d711d91f64fa",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13000,8 +13081,8 @@
               "name": "end_case_condition_1_log",
               "config": {},
               "test": "",
-              "uuid": "9aafa03a-0822-4ea7-980c-0a594206b2e6",
-              "destination_block": "719e4056-bdd0-593f-a0c8-e255ece0180c",
+              "uuid": "7e4eb3da-35fc-4d22-8c42-64cf7c508770",
+              "destination_block": "4d52e736-7b89-538c-89c4-17e4ed5dc356",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -13016,7 +13097,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.medium_inflection and score_perc < assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 490
+                        "line": 496
                       },
                       "name": "End",
                       "uuid": "a7d1d4b4-8704-5c4e-b2bf-6a047180c846"
@@ -13025,7 +13106,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 496
+                        "line": 502
                       },
                       "type": "log"
                     },
@@ -13042,7 +13123,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "719e4056-bdd0-593f-a0c8-e255ece0180c",
+          "uuid": "4d52e736-7b89-538c-89c4-17e4ed5dc356",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13055,8 +13136,8 @@
               "name": "assessment_data.medium_result_page.id",
               "config": {},
               "test": "",
-              "uuid": "0269d315-9aae-4dad-8e41-77cb101d429f",
-              "destination_block": "db543502-5653-538b-ae63-afbe09db904a",
+              "uuid": "8edd262d-894e-4c67-9301-2bc30c471d7f",
+              "destination_block": "324fc51b-f4eb-5ad6-8f6f-731d3ca00644",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -13071,7 +13152,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.medium_inflection and score_perc < assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 490
+                        "line": 496
                       },
                       "name": "End",
                       "uuid": "a7d1d4b4-8704-5c4e-b2bf-6a047180c846"
@@ -13080,7 +13161,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 497
+                        "line": 503
                       },
                       "type": "expression"
                     },
@@ -13097,7 +13178,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "db543502-5653-538b-ae63-afbe09db904a",
+          "uuid": "324fc51b-f4eb-5ad6-8f6f-731d3ca00644",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13110,8 +13191,8 @@
               "name": "Exit for DisplayEndPage",
               "config": {},
               "test": "true",
-              "uuid": "f167aeaf-af13-4904-b0f2-45672de4c186",
-              "destination_block": "4a783711-66af-51b9-8123-fbb117fa66a4",
+              "uuid": "b96224fb-bd07-43d1-9376-f9238a3ad1b0",
+              "destination_block": "cc311bb4-1f77-5fbb-bb1b-2be1124b21c2",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -13126,7 +13207,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.medium_inflection and score_perc < assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 490
+                        "line": 496
                       },
                       "name": "End",
                       "uuid": "a7d1d4b4-8704-5c4e-b2bf-6a047180c846"
@@ -13134,7 +13215,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 499
+                        "line": 505
                       },
                       "then": {},
                       "type": "then"
@@ -13152,7 +13233,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "c70b05c4-2924-5ce0-b306-f234efc25ec2",
+          "uuid": "ccd986f7-20b4-5560-9ec7-f8828250d0aa",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13165,8 +13246,8 @@
               "name": "concatenate(\"@slug\", \"_\", \"@version\", \"_risk\")",
               "config": {},
               "test": "",
-              "uuid": "9e719065-1da7-4e0d-8f97-2b5482682d70",
-              "destination_block": "f4a80c77-584e-57a2-9553-413fd5b91c47",
+              "uuid": "33ff84c9-fcd4-4c0c-9a2c-d4b098b26126",
+              "destination_block": "57784053-643e-5e8b-b59d-032e7cd30af4",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -13181,7 +13262,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 479
+                        "line": 485
                       },
                       "name": "End",
                       "uuid": "32ce1416-2d08-52eb-8ba7-089d0fc5fd7f"
@@ -13190,7 +13271,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 482
+                        "line": 488
                       },
                       "type": "expression"
                     },
@@ -13209,7 +13290,7 @@
             "value": "\"high\""
           },
           "tags": [],
-          "uuid": "f4a80c77-584e-57a2-9553-413fd5b91c47",
+          "uuid": "57784053-643e-5e8b-b59d-032e7cd30af4",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13222,8 +13303,8 @@
               "name": "@result_tag",
               "config": {},
               "test": "",
-              "uuid": "1df12c25-0b76-424f-ac92-e0eab92bfac7",
-              "destination_block": "0086d491-14c6-5df0-a568-5b704e0b60e4",
+              "uuid": "7c79ace4-efed-4d9e-94a2-115d4f7004e2",
+              "destination_block": "0b8ffda5-98ff-5eef-8f93-3d8729f45987",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -13238,7 +13319,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 479
+                        "line": 485
                       },
                       "name": "End",
                       "uuid": "32ce1416-2d08-52eb-8ba7-089d0fc5fd7f"
@@ -13246,7 +13327,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 483
+                        "line": 489
                       },
                       "type": "write_result",
                       "write_result": {}
@@ -13263,10 +13344,10 @@
           "name": "end_case_condition_0_log",
           "type": "Core.Log",
           "config": {
-            "message": "8babea68-2f10-448d-99e8-dc06da303510"
+            "message": "a06dbf55-935f-4ff1-8a21-05e065bcb6d8"
           },
           "tags": [],
-          "uuid": "0086d491-14c6-5df0-a568-5b704e0b60e4",
+          "uuid": "0b8ffda5-98ff-5eef-8f93-3d8729f45987",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13279,8 +13360,8 @@
               "name": "end_case_condition_0_log",
               "config": {},
               "test": "",
-              "uuid": "e22959cd-93d8-4c88-9b3c-8fd6f4b672de",
-              "destination_block": "b96ce683-a0fc-5688-88d5-89e376da3f7a",
+              "uuid": "807f72f4-c683-44e1-a305-48468cb52385",
+              "destination_block": "60a2df6b-011f-59d7-8064-8bba14cc2c2c",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -13295,7 +13376,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 479
+                        "line": 485
                       },
                       "name": "End",
                       "uuid": "32ce1416-2d08-52eb-8ba7-089d0fc5fd7f"
@@ -13304,7 +13385,7 @@
                       "log": {},
                       "meta": {
                         "column": 3,
-                        "line": 484
+                        "line": 490
                       },
                       "type": "log"
                     },
@@ -13321,7 +13402,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "b96ce683-a0fc-5688-88d5-89e376da3f7a",
+          "uuid": "60a2df6b-011f-59d7-8064-8bba14cc2c2c",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13334,8 +13415,8 @@
               "name": "assessment_data.high_result_page.id",
               "config": {},
               "test": "",
-              "uuid": "289fd24d-41e5-4b74-ae90-40b2dbcd89ed",
-              "destination_block": "7c51ced6-2d8d-52c8-80f8-43a052f4e88c",
+              "uuid": "38169636-0130-4389-8238-2389ee6f753d",
+              "destination_block": "f219286b-8905-596e-909e-0a2b404cfad5",
               "semantic_label": "",
               "vendor_metadata": {}
             }
@@ -13350,7 +13431,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 479
+                        "line": 485
                       },
                       "name": "End",
                       "uuid": "32ce1416-2d08-52eb-8ba7-089d0fc5fd7f"
@@ -13359,7 +13440,7 @@
                       "expression": {},
                       "meta": {
                         "column": 3,
-                        "line": 485
+                        "line": 491
                       },
                       "type": "expression"
                     },
@@ -13376,7 +13457,7 @@
           "type": "Core.Case",
           "config": {},
           "tags": [],
-          "uuid": "7c51ced6-2d8d-52c8-80f8-43a052f4e88c",
+          "uuid": "f219286b-8905-596e-909e-0a2b404cfad5",
           "ui_metadata": {
             "canvas_coordinates": {
               "x": 0,
@@ -13389,8 +13470,8 @@
               "name": "Exit for DisplayEndPage",
               "config": {},
               "test": "true",
-              "uuid": "f13f3f14-75e3-4646-bc86-c592e16e326e",
-              "destination_block": "4a783711-66af-51b9-8123-fbb117fa66a4",
+              "uuid": "7f26e853-734e-4bc6-9bd6-fcf45b277a30",
+              "destination_block": "cc311bb4-1f77-5fbb-bb1b-2be1124b21c2",
               "semantic_label": null,
               "vendor_metadata": {}
             }
@@ -13405,7 +13486,7 @@
                       "condition": "skip_count < skip_threshold and score_perc >= assessment_data.high_inflection",
                       "meta": {
                         "column": 1,
-                        "line": 479
+                        "line": 485
                       },
                       "name": "End",
                       "uuid": "32ce1416-2d08-52eb-8ba7-089d0fc5fd7f"
@@ -13413,7 +13494,7 @@
                     "card_item": {
                       "meta": {
                         "column": 3,
-                        "line": 487
+                        "line": 493
                       },
                       "then": {},
                       "type": "then"
@@ -13426,11 +13507,11 @@
           }
         }
       ],
-      "last_modified": "2024-08-12T10:42:37.808075Z",
+      "last_modified": "2024-08-21T10:09:32.873719Z",
       "uuid": "b01adce0-ce89-53ee-adea-025a72ea5105",
       "languages": [
         {
-          "id": "09406b97-f5bb-458d-b787-5c67b8725848",
+          "id": "bd2bfff0-7f62-4fea-bf3a-6abc67db7639",
           "label": "English",
           "variant": null,
           "iso_639_3": "eng",

--- a/Assessments/assessments.md
+++ b/Assessments/assessments.md
@@ -49,9 +49,37 @@ version: "0.1.0"
 columns: [] 
 -->
 
-| Key            | Value            |
-| -------------- | ---------------- |
-| assessment_tag | placeholder_form |
+| Key            | Value     |
+| -------------- | --------- |
+| assessment_tag | test-form |
+
+## Get Assessment
+
+We fetch the assessment as configured in the assessment_tag. At this point we initialise the following variables used throughout the Journey:
+
+* `assessment_data`, the full assessment data
+* `questions`, the questions to be asked in the form
+* `locale`, the locale of the form
+* `slug`
+* `version`
+* `question_num`, the current question number
+* `score`, the total assessment score, used at the end to determine which page to show the user. Skipped questions are excluded from this score
+* `min`,
+* `max`,
+* `assertion`,
+* `get_today`, today
+* `get_year`, the current year
+* `range`, the maximum age range, default 120
+* `max_score`, the maximum score possible for this user, skipped questions are excluded from this score
+* `skip_count`, the number of questions skipped
+* `skip_threshold`, how many questions the user must skip to see the skip message at the end of the form
+* `keywords`, the keywords that will trigger the explainer text
+
+We also write the follwing flow results:
+
+* `@slug_@version_start`, the form tag
+* `locale`, the locale of the form
+* `version`, the version of the form
 
 ```stack
 card GetAssessment, then: CheckEnd do
@@ -263,6 +291,12 @@ card ValidateInput
      when assertion == false and questions[question_num].question_type == "integer_question",
      then: QuestionError do
   log("Error input")
+end
+
+card ValidateInput
+     when not has_member(map(question.answers, & &1.answer), question_response),
+     then: QuestionError do
+  log("Invalid input")
 end
 
 card ValidateInput, then: QuestionResponse do
@@ -579,6 +613,16 @@ card QuestionResponse, then: CheckEnd do
 end
 
 ```
+
+## End
+
+We record the final result of the Form, and display the correct End page (high, medium, low, skip_high).
+
+We record the following Flow Results:
+
+* `@slug_@version_risk`, `skip_high`, `low`, `medium`, or `high` depending on the risk.
+* `@slug_@version_score`, the user's score at the end of the form
+* `@slug_@version_max_score`, the user's maximum possible score at the end of the form
 
 ```stack
 card End


### PR DESCRIPTION
This adds catch-all error handling to forms, e.g. if a person answers "bla" to a question that only has options "Always", "Sometimes", and "Never", then they will receive an error and the question will be resent.